### PR TITLE
[FEAT] weather api 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,11 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	//webclient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	//Json parse
+	implementation 'org.json:json:20210307'
 
 }
 

--- a/src/main/java/nova/mjs/MjsApplication.java
+++ b/src/main/java/nova/mjs/MjsApplication.java
@@ -2,9 +2,11 @@ package nova.mjs;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 //절대 바꾸면 안 됨(이름을) - 모든 프로젝트의 근간이 되는 class
 @SpringBootApplication
+@EnableScheduling
 public class MjsApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/nova/mjs/util/WebClientConfig.java
+++ b/src/main/java/nova/mjs/util/WebClientConfig.java
@@ -1,0 +1,17 @@
+package nova.mjs.util;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean(name = "openWeatherMapClient")
+    public WebClient openWeatherMapClient(WebClient.Builder builder) {
+        return builder
+                .baseUrl("https://api.openweathermap.org")
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+}

--- a/src/main/java/nova/mjs/util/exception/ErrorCode.java
+++ b/src/main/java/nova/mjs/util/exception/ErrorCode.java
@@ -35,9 +35,12 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND,"MEMBER_NOT_FOUND" ,"[MJS] 회원 정보를 찾을 수 없습니다." ),
     PASSWORD_IS_INVALID(HttpStatus.BAD_REQUEST, "PASSWORD_IS_INVALID", "[MJS] 비밀번호가 잘못되었습니다" ),
     SAME_PASSWORD_NOT_ALLOWED(HttpStatus.BAD_REQUEST,"SAME_PASSWORD_NOT_ALLOWED" , "[MJS] 이전과 동일한 비밀번호로는 변경할 수 없습니다."),
-    DUPLICATE_EMAIL_EXCEPTION(HttpStatus.BAD_REQUEST,"DUPLICATE_EMAIL_EXCEPTION", "[MJS] 이미 존재하는 이메일입니다." );
+    DUPLICATE_EMAIL_EXCEPTION(HttpStatus.BAD_REQUEST,"DUPLICATE_EMAIL_EXCEPTION", "[MJS] 이미 존재하는 이메일입니다." ),
 
-
+    // 날씨 에러
+    API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "API_CALL_FAILED", "[MJS] API 호출 중 오류 발생하였습니다."),
+    JSON_PARSING_FAILED(HttpStatus.BAD_REQUEST, "JSON_PARSING_FAILED", "[MJS] JSON 데이터 파싱 오류입니다."),
+    NO_DATA_FOUND(HttpStatus.NOT_FOUND, "NO_DATA_FOUND", "[MJS] 저장된 날씨 데이터가 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/nova/mjs/weather/Weather.java
+++ b/src/main/java/nova/mjs/weather/Weather.java
@@ -1,0 +1,64 @@
+package nova.mjs.weather;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "weather")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Weather {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String location;
+
+    @Column(nullable = false)
+    private double temperature;
+
+    @Column(nullable = false)
+    private double feelsLike;
+
+    @Column(nullable = false)
+    private int humidity;
+
+    @Column(nullable = false)
+    private String weatherMain; // 날씨 그룹 (예: Rain, Clear)
+
+    @Column(nullable = false)
+    private String weatherDescription; // 상세 설명 (예: light rain)
+
+    @Column(nullable = false)
+    private String weatherIcon; // 날씨 아이콘 코드 (예: 10n)
+
+    @Column(nullable = false)
+    private double minTemperature;
+
+    @Column(nullable = false)
+    private double maxTemperature;
+
+    @Column(nullable = false)
+    private double pm10;
+
+    @Column(nullable = false)
+    private double pm2_5;
+
+    @Column(nullable = false)
+    private String pm10Category;
+
+    @Column(nullable = false)
+    private String pm2_5Category;
+
+    @Column(nullable = false)
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/nova/mjs/weather/WeatherController.java
+++ b/src/main/java/nova/mjs/weather/WeatherController.java
@@ -1,0 +1,19 @@
+package nova.mjs.weather;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/weather")
+@RequiredArgsConstructor
+public class WeatherController {
+
+    private final WeatherService weatherService;
+
+    @GetMapping
+    public Weather getLatestWeather() {
+        return weatherService.getStoredWeather();
+    }
+}

--- a/src/main/java/nova/mjs/weather/WeatherRepository.java
+++ b/src/main/java/nova/mjs/weather/WeatherRepository.java
@@ -1,0 +1,8 @@
+package nova.mjs.weather;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WeatherRepository extends JpaRepository<Weather, Long> {
+}

--- a/src/main/java/nova/mjs/weather/exception/WeatherAPICallException.java
+++ b/src/main/java/nova/mjs/weather/exception/WeatherAPICallException.java
@@ -1,0 +1,9 @@
+package nova.mjs.weather.exception;
+
+import nova.mjs.util.exception.ErrorCode;
+
+public class WeatherAPICallException extends WeatherException {
+    public WeatherAPICallException() {
+        super(ErrorCode.API_CALL_FAILED);
+    }
+}

--- a/src/main/java/nova/mjs/weather/exception/WeatherException.java
+++ b/src/main/java/nova/mjs/weather/exception/WeatherException.java
@@ -1,0 +1,13 @@
+package nova.mjs.weather.exception;
+
+import nova.mjs.util.exception.BusinessBaseException;
+import nova.mjs.util.exception.ErrorCode;
+
+public class WeatherException extends BusinessBaseException {
+    public WeatherException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+    public WeatherException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/nova/mjs/weather/exception/WeatherJsonParseException.java
+++ b/src/main/java/nova/mjs/weather/exception/WeatherJsonParseException.java
@@ -1,0 +1,9 @@
+package nova.mjs.weather.exception;
+
+import nova.mjs.util.exception.ErrorCode;
+
+public class WeatherJsonParseException extends WeatherException {
+    public WeatherJsonParseException() {
+        super(ErrorCode.JSON_PARSING_FAILED);
+    }
+}

--- a/src/main/java/nova/mjs/weather/exception/WeatherNotFoundException.java
+++ b/src/main/java/nova/mjs/weather/exception/WeatherNotFoundException.java
@@ -1,0 +1,8 @@
+package nova.mjs.weather.exception;
+
+import nova.mjs.util.exception.ErrorCode;
+
+public class WeatherNotFoundException extends WeatherException {
+    public WeatherNotFoundException() {super(ErrorCode.NO_DATA_FOUND); }
+
+}


### PR DESCRIPTION
- 매시간 날씨 및 대기오염 데이터를 가져오는 스케줄러 구현
- 온도, 체감온도, 습도, 대기질(PM10, PM2.5) 정보를 DB에 저장
- 미세먼지(PM10) 및 초미세먼지(PM2.5) 등급을 아래 기준으로 '좋음', '보통', '나쁨', '매우 나쁨'으로 분류
![스크린샷 2025-02-18 오후 3 10 33](https://github.com/user-attachments/assets/431043b2-17a3-4116-922b-9f160e051757)
- OpenWeatherMap API 기반 날씨 아이콘 URL 추가
- 최신 날씨 데이터를 조회할 수 있는 API 엔드포인트 추가 (/api/v1/weather)
- @Scheduled을 활용하여 매 정각마다 자동 업데이트