### PR TITLE
News

### DIFF
--- a/src/main/java/nova/mjs/news/controller/NewsController.java
+++ b/src/main/java/nova/mjs/news/controller/NewsController.java
@@ -2,7 +2,6 @@ package nova.mjs.news.controller;
 
 import lombok.RequiredArgsConstructor;
 import nova.mjs.news.DTO.NewsResponseDTO;
-import nova.mjs.news.entity.News;
 import nova.mjs.news.service.NewsService;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/nova/mjs/news/entity/News.java
+++ b/src/main/java/nova/mjs/news/entity/News.java
@@ -12,8 +12,12 @@ import nova.mjs.member.Member;
 @Table(name = "MJU_News")
 public class News {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "news_id")
-    private Long id; //기사 id
+    private Long id;
+
+    @Column(name = "news_index", nullable = false, unique = true)
+    private Long newsIndex; //기사 인덱스
 
     @Column(nullable = false)
     private String title; //기사 제목
@@ -52,9 +56,9 @@ public class News {
         }
     }
 
-    public static News createNews(Long id, String title, String date, String reporter, String imageUrl, String summary, String link, String category) {
+    public static News createNews(Long newsIndex, String title, String date, String reporter, String imageUrl, String summary, String link, String category) {
         return News.builder()
-                .id(id)
+                .newsIndex(newsIndex)
                 .title(title)
                 .date(date)
                 .reporter(reporter)

--- a/src/main/java/nova/mjs/news/entity/News.java
+++ b/src/main/java/nova/mjs/news/entity/News.java
@@ -12,9 +12,8 @@ import nova.mjs.member.Member;
 @Table(name = "MJU_News")
 public class News {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "news_id")
-    private Long id;
+    private Long id; //기사 id
 
     @Column(nullable = false)
     private String title; //기사 제목
@@ -31,7 +30,7 @@ public class News {
     @Column(columnDefinition = "TEXT")
     private String summary; //기사 첫 문단
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String link; //기사 링크
 
     @Column(nullable = false, length = 20)
@@ -53,8 +52,9 @@ public class News {
         }
     }
 
-    public static News createNews(String title, String date, String reporter, String imageUrl, String summary, String link, String category) {
+    public static News createNews(Long id, String title, String date, String reporter, String imageUrl, String summary, String link, String category) {
         return News.builder()
+                .id(id)
                 .title(title)
                 .date(date)
                 .reporter(reporter)

--- a/src/main/java/nova/mjs/news/repository/NewsRepository.java
+++ b/src/main/java/nova/mjs/news/repository/NewsRepository.java
@@ -12,14 +12,11 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     //카테고리 기준으로 탐색
     List<News> findByCategory(News.Category category);
 
-    //기사 제목을 기준으로 존재 여부 확인
-    boolean existsByTitle(String title);
-
     //링크를 기준으로 중복 여부 확인
     boolean existsByLink(String link);
 
-    //기사 아이디를 기준으로 중복 여부 확인
-    boolean existsById(Long id);
+    //기사 인덱스를 기준으로 중복 여부 확인
+    boolean existsByNewsIndex(Long newsIndex);
 
     //카테고리 기준으로 존재 여부 확인
     boolean existsByCategory(News.Category category);

--- a/src/main/java/nova/mjs/news/repository/NewsRepository.java
+++ b/src/main/java/nova/mjs/news/repository/NewsRepository.java
@@ -18,6 +18,9 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     //링크를 기준으로 중복 여부 확인
     boolean existsByLink(String link);
 
+    //기사 아이디를 기준으로 중복 여부 확인
+    boolean existsById(Long id);
+
     //카테고리 기준으로 존재 여부 확인
     boolean existsByCategory(News.Category category);
 

--- a/src/main/java/nova/mjs/news/repository/NewsRepository.java
+++ b/src/main/java/nova/mjs/news/repository/NewsRepository.java
@@ -15,6 +15,9 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     //기사 제목을 기준으로 존재 여부 확인
     boolean existsByTitle(String title);
 
+    //링크를 기준으로 중복 여부 확인
+    boolean existsByLink(String link);
+
     //카테고리 기준으로 존재 여부 확인
     boolean existsByCategory(News.Category category);
 

--- a/src/main/java/nova/mjs/util/scheduler/SchedulerService.java
+++ b/src/main/java/nova/mjs/util/scheduler/SchedulerService.java
@@ -43,8 +43,8 @@ public class SchedulerService {
         });
     }
 
-    //뉴스 크롤링 스케줄링 (매시간 정각 실행)
-    @Scheduled(cron = "0 0 * * * *")
+    //뉴스 크롤링 스케줄링 (매주 월요일 정각마다 실행)
+    @Scheduled(cron = "0 0 * * 1 *")
     public void scheduledCrawlNews() {
         log.info("[스케쥴러] 매시간 5분마다 기사 크롤링 실행");
         CompletableFuture.runAsync(() -> {
@@ -65,7 +65,9 @@ public class SchedulerService {
     }
 
     //식단 데이터 크롤링 스케줄링 (매주 토, 일, 월 19:00 실행)
-    @Scheduled(cron = "0 0 19 * * SAT,SUN,MON")
+    @Scheduled(cron = "0 0 19 * * 6") // 매주 토요일 19:00 실행
+    @Scheduled(cron = "0 0 19 * * 7") // 매주 일요일 19:00 실행
+    @Scheduled(cron = "0 0 19 * * 1") // 매주 월요일 19:00 실행
     public void scheduledCrawlWeeklyMenu() {
         log.info("[스케쥴러] 매주 토, 일, 월 19시에 식단 크롤링 실행");
         CompletableFuture.runAsync(() -> {


### PR DESCRIPTION
-스케줄러 표현식에 약간의 문제가 있는 것 같아, 표현식을 수정하였습니다.

-기존 명대신문 기사를 크롤링하는 과정에서, 제목을 기준으로 중복 여부를 파악했으나 링크에 기재된 기사의 아이디를 기준으로 중복 여부를 파악하도록 수정하였습니다.
-기사의 아이디는 따로 컬럼을 생성하여 엔티티에 지정하였고, ID는 스프링에서 제공되는 ID 컬럼을 사용했습니다.(실제 명대신문 홈페이지의 기사 순서와의 차이 문제)