### PR TITLE
Add department notice crawler with parsers and integration to controller/scheduler

### DIFF
--- a/src/main/java/nova/mjs/domain/thingo/department/controller/DepartmentController.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/controller/DepartmentController.java
@@ -8,6 +8,7 @@ import nova.mjs.domain.thingo.department.dto.DepartmentScheduleDTO;
 import nova.mjs.domain.thingo.department.entity.enumList.College;
 import nova.mjs.domain.thingo.department.entity.enumList.DepartmentName;
 import nova.mjs.domain.thingo.department.service.info.DepartmentInfoQueryService;
+import nova.mjs.domain.thingo.department.service.notice.DepartmentNoticeCrawlingService;
 import nova.mjs.domain.thingo.department.service.notice.DepartmentNoticeQueryService;
 import nova.mjs.domain.thingo.department.service.notice.StudentCouncilNoticeQueryService;
 import nova.mjs.domain.thingo.department.service.schedule.DepartmentScheduleService;
@@ -29,6 +30,7 @@ public class DepartmentController {
     private final DepartmentScheduleService departmentScheduleService;
     private final StudentCouncilNoticeQueryService studentCouncilNoticeQueryService;
     private final DepartmentNoticeQueryService departmentNoticeQueryService;
+    private final DepartmentNoticeCrawlingService departmentNoticeCrawlingService;
 
     /* ------------------------------------------------------------------
      *  학과 정보 (단건)
@@ -116,4 +118,9 @@ public class DepartmentController {
                 )
         );
     }
+    @PostMapping("/notices/crawl")
+    public ResponseEntity<ApiResponse<DepartmentNoticeCrawlingService.CrawlReport>> crawlDepartmentNotices() {
+        return ResponseEntity.ok(ApiResponse.success(departmentNoticeCrawlingService.crawlAll()));
+    }
+
 }

--- a/src/main/java/nova/mjs/domain/thingo/department/repository/DepartmentNoticeRepository.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/repository/DepartmentNoticeRepository.java
@@ -13,4 +13,6 @@ public interface DepartmentNoticeRepository extends JpaRepository<DepartmentNoti
             Department department,
             Pageable pageable
     );
+
+    boolean existsByDepartmentAndLink(Department department, String link);
 }

--- a/src/main/java/nova/mjs/domain/thingo/department/service/notice/DepartmentNoticeCrawlingService.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/service/notice/DepartmentNoticeCrawlingService.java
@@ -1,0 +1,214 @@
+package nova.mjs.domain.thingo.department.service.notice;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nova.mjs.domain.thingo.department.entity.Department;
+import nova.mjs.domain.thingo.department.entity.DepartmentNotice;
+import nova.mjs.domain.thingo.department.repository.DepartmentNoticeRepository;
+import nova.mjs.domain.thingo.department.repository.DepartmentRepository;
+import nova.mjs.domain.thingo.department.service.notice.crawl.CrawledDepartmentNotice;
+import nova.mjs.domain.thingo.department.service.notice.crawl.DepartmentNoticeListParser;
+import nova.mjs.domain.thingo.department.service.notice.crawl.DepartmentNoticeSource;
+import nova.mjs.domain.thingo.department.service.notice.crawl.DepartmentNoticeSourceRegistry;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DepartmentNoticeCrawlingService {
+
+    private final DepartmentRepository departmentRepository;
+    private final DepartmentNoticeRepository departmentNoticeRepository;
+    private final List<DepartmentNoticeListParser> parsers;
+
+    @Transactional
+    public CrawlReport crawlAll() {
+        List<SourceCrawlResult> results = new ArrayList<>();
+
+        for (DepartmentNoticeSource source : DepartmentNoticeSourceRegistry.sources()) {
+            try {
+                results.add(crawlSingleSource(source));
+            } catch (Exception e) {
+                log.error("[MJS][DepartmentNotice] source={} 크롤링 실패", source.label(), e);
+                results.add(SourceCrawlResult.fail(source.label(), source.url(), e.getMessage()));
+            }
+        }
+
+        return CrawlReport.of(results);
+    }
+
+    private SourceCrawlResult crawlSingleSource(DepartmentNoticeSource source) throws IOException {
+        Optional<Department> department = resolveDepartment(source);
+        if (department.isEmpty()) {
+            log.warn("[MJS][DepartmentNotice] source={} 에 해당하는 Department가 없어 스킵합니다.", source.label());
+            return SourceCrawlResult.skip(source.label(), source.url(), "department 매핑 없음");
+        }
+
+        Document document = Jsoup.connect(source.url())
+                .userAgent("Mozilla/5.0")
+                .timeout(10_000)
+                .get();
+
+        ParseOutcome outcome = parseWithFallback(document, source);
+        List<CrawledDepartmentNotice> crawled = outcome.items();
+
+        if (crawled.isEmpty()) {
+            log.warn("[MJS][DepartmentNotice] source={} 파싱 결과 0건 (parser={})", source.label(), outcome.parserName());
+            return SourceCrawlResult.fail(source.label(), source.url(), "파싱 결과 0건");
+        }
+
+        List<DepartmentNotice> newNotices = new ArrayList<>();
+        for (CrawledDepartmentNotice item : crawled) {
+            if (departmentNoticeRepository.existsByDepartmentAndLink(department.get(), item.link())) {
+                continue;
+            }
+
+            newNotices.add(DepartmentNotice.builder()
+                    .departmentNoticeUuid(UUID.randomUUID())
+                    .department(department.get())
+                    .title(item.title())
+                    .date(item.date())
+                    .link(item.link())
+                    .build());
+        }
+
+        if (!newNotices.isEmpty()) {
+            departmentNoticeRepository.saveAll(newNotices);
+        }
+
+        log.info("[MJS][DepartmentNotice] source={} parser={} 파싱 {}건 / 신규 저장 {}건",
+                source.label(), outcome.parserName(), crawled.size(), newNotices.size());
+
+        return SourceCrawlResult.success(source.label(), source.url(), outcome.parserName(), crawled.size(), newNotices.size());
+    }
+
+    private ParseOutcome parseWithFallback(Document document, DepartmentNoticeSource source) {
+        DepartmentNoticeListParser preferred = parsers.stream()
+                .filter(p -> p.supports(source.sourceType()))
+                .findFirst()
+                .orElse(null);
+
+        List<ParseOutcome> outcomes = new ArrayList<>();
+
+        if (preferred != null) {
+            List<CrawledDepartmentNotice> preferredItems = preferred.parse(document, source);
+            outcomes.add(new ParseOutcome(preferred.getClass().getSimpleName(), preferredItems));
+            if (!preferredItems.isEmpty()) {
+                return outcomes.get(0);
+            }
+        }
+
+        for (DepartmentNoticeListParser parser : parsers) {
+            if (parser == preferred) {
+                continue;
+            }
+            List<CrawledDepartmentNotice> parsed = parser.parse(document, source);
+            outcomes.add(new ParseOutcome(parser.getClass().getSimpleName(), parsed));
+        }
+
+        return outcomes.stream()
+                .max(Comparator.comparingInt(o -> o.items().size()))
+                .orElse(new ParseOutcome("NONE", List.of()));
+    }
+
+    private Optional<Department> resolveDepartment(DepartmentNoticeSource source) {
+        if (source.departmentName() == null) {
+            return departmentRepository.findByCollegeAndDepartmentNameIsNull(source.college());
+        }
+
+        return departmentRepository.findByCollegeAndDepartmentName(source.college(), source.departmentName());
+    }
+
+    private record ParseOutcome(String parserName, List<CrawledDepartmentNotice> items) {
+    }
+
+    @Getter
+    public static class CrawlReport {
+        private final int total;
+        private final int success;
+        private final int failed;
+        private final int skipped;
+        private final List<SourceCrawlResult> results;
+
+        private CrawlReport(int total, int success, int failed, int skipped, List<SourceCrawlResult> results) {
+            this.total = total;
+            this.success = success;
+            this.failed = failed;
+            this.skipped = skipped;
+            this.results = results;
+        }
+
+        public static CrawlReport of(List<SourceCrawlResult> results) {
+            int total = results.size();
+            int success = (int) results.stream().filter(SourceCrawlResult::isSuccess).count();
+            int skipped = (int) results.stream().filter(SourceCrawlResult::isSkipped).count();
+            int failed = total - success - skipped;
+            return new CrawlReport(total, success, failed, skipped, results);
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class SourceCrawlResult {
+        private String sourceLabel;
+        private String sourceUrl;
+        private String parser;
+        private int parsedCount;
+        private int savedCount;
+        private boolean success;
+        private boolean skipped;
+        private String message;
+
+        public static SourceCrawlResult success(String label, String url, String parser, int parsedCount, int savedCount) {
+            return SourceCrawlResult.builder()
+                    .sourceLabel(label)
+                    .sourceUrl(url)
+                    .parser(parser)
+                    .parsedCount(parsedCount)
+                    .savedCount(savedCount)
+                    .success(true)
+                    .skipped(false)
+                    .message("ok")
+                    .build();
+        }
+
+        public static SourceCrawlResult fail(String label, String url, String message) {
+            return SourceCrawlResult.builder()
+                    .sourceLabel(label)
+                    .sourceUrl(url)
+                    .parser("unknown")
+                    .parsedCount(0)
+                    .savedCount(0)
+                    .success(false)
+                    .skipped(false)
+                    .message(message)
+                    .build();
+        }
+
+        public static SourceCrawlResult skip(String label, String url, String message) {
+            return SourceCrawlResult.builder()
+                    .sourceLabel(label)
+                    .sourceUrl(url)
+                    .parser("none")
+                    .parsedCount(0)
+                    .savedCount(0)
+                    .success(false)
+                    .skipped(true)
+                    .message(message)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/AbstractDepartmentNoticeParser.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/AbstractDepartmentNoticeParser.java
@@ -1,0 +1,105 @@
+package nova.mjs.domain.thingo.department.service.notice.crawl;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+abstract class AbstractDepartmentNoticeParser implements DepartmentNoticeListParser {
+
+    protected List<CrawledDepartmentNotice> parseRows(
+            Elements rows,
+            DepartmentNoticeSource source,
+            String titleSelector,
+            String linkSelector,
+            String dateSelector
+    ) {
+        List<CrawledDepartmentNotice> notices = new ArrayList<>();
+
+        for (Element row : rows) {
+            String title = row.select(titleSelector).text().trim();
+            String link = row.select(linkSelector).attr("href").trim();
+            String dateText = row.select(dateSelector).text().trim();
+
+            if (title.isBlank() || link.isBlank()) {
+                continue;
+            }
+
+            LocalDateTime date = parseDate(dateText);
+            String absoluteLink = toAbsoluteUrl(source.url(), row.select(linkSelector).attr("abs:href"), link);
+
+            if (date == null || absoluteLink.isBlank()) {
+                continue;
+            }
+
+            notices.add(new CrawledDepartmentNotice(title, date, absoluteLink));
+        }
+
+        return notices;
+    }
+
+    protected LocalDateTime parseDate(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+
+        String normalized = raw
+                .replace('.', '-')
+                .replace('/', '-')
+                .replace("년", "-")
+                .replace("월", "-")
+                .replace("일", "")
+                .trim();
+
+        List<DateTimeFormatter> dateTimeFormats = List.of(
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"),
+                DateTimeFormatter.ofPattern("yyyy-M-d HH:mm")
+        );
+
+        for (DateTimeFormatter formatter : dateTimeFormats) {
+            try {
+                return LocalDateTime.parse(normalized, formatter);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+
+        List<DateTimeFormatter> dateFormats = List.of(
+                DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+                DateTimeFormatter.ofPattern("yyyy-M-d"),
+                DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.ENGLISH)
+        );
+
+        for (DateTimeFormatter formatter : dateFormats) {
+            try {
+                return LocalDate.parse(normalized, formatter).atTime(LocalTime.NOON);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+
+        return null;
+    }
+
+    protected String toAbsoluteUrl(String baseUrl, String absHref, String href) {
+        if (absHref != null && !absHref.isBlank()) {
+            return absHref;
+        }
+
+        if (href == null || href.isBlank()) {
+            return "";
+        }
+
+        try {
+            return URI.create(baseUrl).resolve(href).toString();
+        } catch (Exception e) {
+            return href;
+        }
+    }
+}

--- a/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/CrawledDepartmentNotice.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/CrawledDepartmentNotice.java
@@ -1,0 +1,10 @@
+package nova.mjs.domain.thingo.department.service.notice.crawl;
+
+import java.time.LocalDateTime;
+
+public record CrawledDepartmentNotice(
+        String title,
+        LocalDateTime date,
+        String link
+) {
+}

--- a/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/DepartmentNoticeListParser.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/DepartmentNoticeListParser.java
@@ -1,0 +1,12 @@
+package nova.mjs.domain.thingo.department.service.notice.crawl;
+
+import org.jsoup.nodes.Document;
+
+import java.util.List;
+
+public interface DepartmentNoticeListParser {
+
+    boolean supports(DepartmentNoticeSourceType sourceType);
+
+    List<CrawledDepartmentNotice> parse(Document document, DepartmentNoticeSource source);
+}

--- a/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/DepartmentNoticeSource.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/DepartmentNoticeSource.java
@@ -1,0 +1,13 @@
+package nova.mjs.domain.thingo.department.service.notice.crawl;
+
+import nova.mjs.domain.thingo.department.entity.enumList.College;
+import nova.mjs.domain.thingo.department.entity.enumList.DepartmentName;
+
+public record DepartmentNoticeSource(
+        College college,
+        DepartmentName departmentName,
+        String label,
+        String url,
+        DepartmentNoticeSourceType sourceType
+) {
+}

--- a/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/DepartmentNoticeSourceRegistry.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/DepartmentNoticeSourceRegistry.java
@@ -1,0 +1,74 @@
+package nova.mjs.domain.thingo.department.service.notice.crawl;
+
+import nova.mjs.domain.thingo.department.entity.enumList.College;
+import nova.mjs.domain.thingo.department.entity.enumList.DepartmentName;
+
+import java.util.List;
+
+public final class DepartmentNoticeSourceRegistry {
+
+    private DepartmentNoticeSourceRegistry() {
+    }
+
+    public static List<DepartmentNoticeSource> sources() {
+        return List.of(
+                source(College.HUMANITIES, DepartmentName.CHINESE_LITERATURE, "중국언어문화학과", "https://cll.mju.ac.kr/cll/4835/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.JAPANESE_LITERATURE, "일본언어문화학과", "https://nichibun.mju.ac.kr/nichibun/4862/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.ARABIC_STUDIES, "아랍지역학전공", "https://arab.mju.ac.kr/arab/8470/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.KOREAN_LITERATURE, "국어국문학과", "https://kll.mju.ac.kr/kll/8392/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.KOREAN_LITERATURE, "국어국문학과-학교공지", "https://kll.mju.ac.kr/kll/8657/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.ENGLISH_LITERATURE, "영어영문학과", "https://english.mju.ac.kr/english/6923/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.ENGLISH_LITERATURE, "영어영문학과-학사공지", "https://english.mju.ac.kr/english/6910/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.LIBRARY_SCIENCE, "문헌정보학과-학사공지", "https://lis.mju.ac.kr/lis/5973/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.LIBRARY_SCIENCE, "문헌정보학과-전공공지", "https://lis.mju.ac.kr/lis/7505/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.LIBRARY_SCIENCE, "문헌정보학과-취업공지", "https://lis.mju.ac.kr/lis/5974/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.CREATIVE_WRITING, "문예창작학과", "https://writers.mju.ac.kr/writers/7468/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.CREATIVE_WRITING, "문예창작학과-학생활동", "https://writers.mju.ac.kr/writers/7318/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.CREATIVE_WRITING, "문예창작학과-채용/공모전", "https://writers.mju.ac.kr/writers/7319/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.CREATIVE_WRITING, "문예창작학과-행사안내", "https://writers.mju.ac.kr/writers/8682/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.SOCIAL_SCIENCES, DepartmentName.PUBLIC_ADMINISTRATION, "행정학전공", "https://mjpa.mju.ac.kr/mjpa/6392/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.SOCIAL_SCIENCES, DepartmentName.LAW, "법학과", "https://col.mju.ac.kr/col/1299/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.SOCIAL_SCIENCES, DepartmentName.LAW, "법학과-대학원", "https://col.mju.ac.kr/col/1305/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.SOCIAL_SCIENCES, DepartmentName.LAW, "법학연구소", "https://col.mju.ac.kr/col/1323/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.MEDIA_HUMANLIFE, DepartmentName.DIGITAL_MEDIA_STUDIES, "디지털미디어학과", "https://dm.mju.ac.kr/dm/6438/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.MEDIA_HUMANLIFE, DepartmentName.YOUTH_GUIDANCE_STUDIES, "청소년지도전공", "https://youth.mju.ac.kr/youth/6858/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.MEDIA_HUMANLIFE, DepartmentName.CHILD_STUDIES, "아동학전공", "https://child.mju.ac.kr/child/7440/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.AI_SOFTWARE, DepartmentName.DIGITAL_CONTENT_DESIGN_STUDIES, "디지털콘텐츠디자인학과-학생공지", "https://dcd.mju.ac.kr/dcd/7361/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.AI_SOFTWARE, DepartmentName.DIGITAL_CONTENT_DESIGN_STUDIES, "디지털콘텐츠디자인학과-학과공지", "https://dcd.mju.ac.kr/dcd/7377/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.AI_SOFTWARE, DepartmentName.DIGITAL_CONTENT_DESIGN_STUDIES, "디지털콘텐츠디자인학과-취업공지", "https://dcd.mju.ac.kr/dcd/7378/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.ART_HISTORY_DEPARTMENT, "미술사학과-일반공지", "https://arthistory.mju.ac.kr/arthistory/7493/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.ART_HISTORY_DEPARTMENT, "미술사학과-취업공지", "https://arthistory.mju.ac.kr/arthistory/7494/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.ART_HISTORY_DEPARTMENT, "미술사학과-기타", "https://arthistory.mju.ac.kr/arthistory/7495/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.HISTORY_DEPARTMENT, "사학과", "https://mjhistory.mju.ac.kr/bbs/gs/195/artclList.do", DepartmentNoticeSourceType.GNUBOARD),
+                source(College.HUMANITIES, DepartmentName.PHILOSOPHY, "철학과-학사공지", "https://phil.mju.ac.kr/philosohpy/6980/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HUMANITIES, DepartmentName.PHILOSOPHY, "철학과-학과공지", "https://phil.mju.ac.kr/philosohpy/7003/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.FUTURE_CONVERGENCE, null, "미래융합대학", "http://future.mju.ac.kr/bbs/board.php?bo_table=notice", DepartmentNoticeSourceType.PHP_BOARD),
+                source(College.HUMANITIES, null, "인문대학", "https://www.mju.ac.kr/humanities/2801/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.SOCIAL_SCIENCES, null, "사회과학대학", "https://www.mju.ac.kr/social/2940/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.BUSINESS, null, "경영대학", "https://www.mju.ac.kr/sba/2223/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.AI_SOFTWARE, null, "인공지능·소프트웨어융합대학", "https://www.mju.ac.kr/ict/9829/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.AI_SOFTWARE, DepartmentName.CONVERGENT_SOFTWARE_STUDIES, "융합소프트웨어학부", "https://www.mju.ac.kr/software/9799/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.AI_SOFTWARE, DepartmentName.CONVERGENT_SOFTWARE_STUDIES, "융합소프트웨어학부-취업/특강", "https://www.mju.ac.kr/software/9800/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.HONOR, null, "아너칼리지", "https://www.mju.ac.kr/mjukr/10235/subview.do", DepartmentNoticeSourceType.MJU_SUBVIEW),
+                source(College.FUTURE_CONVERGENCE, DepartmentName.SOCIAL_WELFARE, "사회복지학과", "https://mjwelfare.mju.ac.kr/default/05/01.php?topmenu=5&left=1", DepartmentNoticeSourceType.PHP_BOARD),
+                source(College.FUTURE_CONVERGENCE, DepartmentName.LAW_ADMINISTRATION, "법행정학과", "https://mjlaw.mju.ac.kr/default/05/01.php?topmenu=5&left=1", DepartmentNoticeSourceType.PHP_BOARD),
+                source(College.FUTURE_CONVERGENCE, DepartmentName.PSYCHOLOGY_THERAPY, "심리치료학과", "https://psy.mju.ac.kr/default/05/01.php?topmenu=5&left=1", DepartmentNoticeSourceType.PHP_BOARD),
+                source(College.FUTURE_CONVERGENCE, DepartmentName.REAL_ESTATE, "부동산학과", "https://real.mju.ac.kr/default/05/01.php?topmenu=5&left=1", DepartmentNoticeSourceType.PHP_BOARD),
+                source(College.FUTURE_CONVERGENCE, DepartmentName.MULTI_DESIGN, "멀티디자인학과", "https://multid.mju.ac.kr/default/05/01.php?topmenu=5&left=1", DepartmentNoticeSourceType.PHP_BOARD),
+                source(College.FUTURE_CONVERGENCE, DepartmentName.FUTURE_CONVERGENCE_BUSINESS, "미래융합경영학과", "https://dfba.mju.ac.kr/default/05/01.php?topmenu=5&left=1", DepartmentNoticeSourceType.PHP_BOARD),
+                source(College.FUTURE_CONVERGENCE, DepartmentName.ACCOUNTING_TAXATION, "회계·세무학과", "https://actx.mju.ac.kr/default/05/01.php?topmenu=5&left=1", DepartmentNoticeSourceType.PHP_BOARD),
+                source(College.FUTURE_CONVERGENCE, null, "비즈HRD학과", "https://bizhrd.mju.ac.kr/default/notice/sub1.php", DepartmentNoticeSourceType.PHP_BOARD),
+                source(College.SOCIAL_SCIENCES, DepartmentName.ECONOMICS, "경제학과", "https://www.mjuecon.org/blog", DepartmentNoticeSourceType.WORDPRESS)
+        );
+    }
+
+    private static DepartmentNoticeSource source(
+            College college,
+            DepartmentName departmentName,
+            String label,
+            String url,
+            DepartmentNoticeSourceType sourceType
+    ) {
+        return new DepartmentNoticeSource(college, departmentName, label, url, sourceType);
+    }
+}

--- a/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/DepartmentNoticeSourceType.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/DepartmentNoticeSourceType.java
@@ -1,0 +1,8 @@
+package nova.mjs.domain.thingo.department.service.notice.crawl;
+
+public enum DepartmentNoticeSourceType {
+    MJU_SUBVIEW,
+    GNUBOARD,
+    PHP_BOARD,
+    WORDPRESS
+}

--- a/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/GnuboardDepartmentNoticeParser.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/GnuboardDepartmentNoticeParser.java
@@ -1,0 +1,22 @@
+package nova.mjs.domain.thingo.department.service.notice.crawl;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class GnuboardDepartmentNoticeParser extends AbstractDepartmentNoticeParser {
+
+    @Override
+    public boolean supports(DepartmentNoticeSourceType sourceType) {
+        return sourceType == DepartmentNoticeSourceType.GNUBOARD || sourceType == DepartmentNoticeSourceType.PHP_BOARD;
+    }
+
+    @Override
+    public List<CrawledDepartmentNotice> parse(Document document, DepartmentNoticeSource source) {
+        Elements rows = document.select("table tbody tr, .board-list tbody tr");
+        return parseRows(rows, source, "td.subject a, td.td_subject a, a", "td.subject a, td.td_subject a, a", "td.datetime, td.date, td:nth-last-child(2)");
+    }
+}

--- a/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/MjuSubViewDepartmentNoticeParser.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/MjuSubViewDepartmentNoticeParser.java
@@ -1,0 +1,26 @@
+package nova.mjs.domain.thingo.department.service.notice.crawl;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class MjuSubViewDepartmentNoticeParser extends AbstractDepartmentNoticeParser {
+
+    @Override
+    public boolean supports(DepartmentNoticeSourceType sourceType) {
+        return sourceType == DepartmentNoticeSourceType.MJU_SUBVIEW;
+    }
+
+    @Override
+    public List<CrawledDepartmentNotice> parse(Document document, DepartmentNoticeSource source) {
+        Elements rows = document.select(".artclTable tbody tr");
+        if (rows.isEmpty()) {
+            rows = document.select("table tbody tr");
+        }
+
+        return parseRows(rows, source, ".artclLinkView, td.title a, a", ".artclLinkView, td.title a, a", "._artclTdRdate, td.date, td:nth-last-child(1)");
+    }
+}

--- a/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/WordpressDepartmentNoticeParser.java
+++ b/src/main/java/nova/mjs/domain/thingo/department/service/notice/crawl/WordpressDepartmentNoticeParser.java
@@ -1,0 +1,22 @@
+package nova.mjs.domain.thingo.department.service.notice.crawl;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class WordpressDepartmentNoticeParser extends AbstractDepartmentNoticeParser {
+
+    @Override
+    public boolean supports(DepartmentNoticeSourceType sourceType) {
+        return sourceType == DepartmentNoticeSourceType.WORDPRESS;
+    }
+
+    @Override
+    public List<CrawledDepartmentNotice> parse(Document document, DepartmentNoticeSource source) {
+        Elements rows = document.select("article, .post, .blog-post");
+        return parseRows(rows, source, "h1 a, h2 a, h3 a, .entry-title a, a", "h1 a, h2 a, h3 a, .entry-title a, a", "time, .entry-date, .posted-on");
+    }
+}

--- a/src/main/java/nova/mjs/util/scheduler/SchedulerService.java
+++ b/src/main/java/nova/mjs/util/scheduler/SchedulerService.java
@@ -3,6 +3,7 @@ package nova.mjs.util.scheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nova.mjs.domain.thingo.broadcast.service.BroadcastService;
+import nova.mjs.domain.thingo.department.service.notice.DepartmentNoticeCrawlingService;
 import nova.mjs.domain.thingo.news.service.NewsService;
 import nova.mjs.domain.thingo.notice.exception.NoticeCrawlingException;
 import nova.mjs.domain.thingo.notice.service.NoticeCrawlingService;
@@ -27,6 +28,7 @@ public class SchedulerService {
     private final WeatherService weatherService;
     private final WeeklyMenuService weeklyMenuService;
     private final NoticeCrawlingService noticeCrawlingService;
+    private final DepartmentNoticeCrawlingService departmentNoticeCrawlingService;
     private final BroadcastService broadcastService;
 
     //날씨 데이터 스케줄링 (매 정각 실행)
@@ -131,6 +133,7 @@ public class SchedulerService {
         CompletableFuture.runAsync(() -> {
             try {
                 noticeCrawlingService.fetchAllNotices();
+                departmentNoticeCrawlingService.crawlAll();
                 log.info("[MJS][Scheduler] Notice crawling completed.");
             } catch (Exception e) {
                 /*


### PR DESCRIPTION
### Motivation
- Provide automated crawling and ingestion of department notice lists from various site types to populate department notices.
- Support multiple source formats (MJU subview, Gnuboard/PHP board, WordPress) with fallback parsing to maximize successful extraction.
- Expose an on-demand crawl API and run department crawling as part of the existing scheduler.

### Description
- Added `DepartmentNoticeCrawlingService` to fetch, parse, deduplicate (by `link`) and persist new `DepartmentNotice` entries and to produce a `CrawlReport` summary.
- Introduced a parsing subsystem under `service.notice.crawl` including `DepartmentNoticeSource`, `DepartmentNoticeSourceRegistry` (preconfigured sources), `DepartmentNoticeSourceType`, `DepartmentNoticeListParser` interface, `AbstractDepartmentNoticeParser` helper, concrete parsers (`MjuSubViewDepartmentNoticeParser`, `GnuboardDepartmentNoticeParser`, `WordpressDepartmentNoticeParser`) and `CrawledDepartmentNotice` record.
- Integrated the crawler into the REST API by adding `POST /api/v1/departments/notices/crawl` in `DepartmentController` and wired the service into the `SchedulerService` to run with existing notice crawling tasks.
- Added repository helper `existsByDepartmentAndLink` to `DepartmentNoticeRepository` to avoid inserting duplicates and implemented parsing fallback logic that picks the parser producing the most items when the preferred parser yields none.

### Testing
- Ran the project's automated test suite with `./mvnw test` and the tests completed successfully.
- Verified application boots and Spring context initializes the new beans by running the application startup (no automated failure observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ff7cc86c083259b23faf9d243b4ef)