### PR TITLE
fix: 학과 공지 생성 시 department null 처리 보완

### DIFF
--- a/src/main/java/nova/mjs/admin/department/notice/controller/AdminStudentCouncilNoticeController.java
+++ b/src/main/java/nova/mjs/admin/department/notice/controller/AdminStudentCouncilNoticeController.java
@@ -55,7 +55,7 @@ public class AdminStudentCouncilNoticeController {
     public ResponseEntity<ApiResponse<AdminStudentCouncilNoticeDTO.Response>> create(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestParam College college,
-            @RequestParam DepartmentName department,
+            @RequestParam(required = false) DepartmentName department,
             @RequestBody AdminStudentCouncilNoticeDTO.Request requestDto
     ) {
         AdminStudentCouncilNoticeDTO.Response created =

--- a/src/main/java/nova/mjs/admin/department/notice/service/AdminStudentCouncilNoticeServiceImpl.java
+++ b/src/main/java/nova/mjs/admin/department/notice/service/AdminStudentCouncilNoticeServiceImpl.java
@@ -163,6 +163,12 @@ public class AdminStudentCouncilNoticeServiceImpl implements AdminStudentCouncil
             throw new DepartmentAdminNotFoundException();
         }
 
+        if (departmentName == null) {
+            return departmentRepository
+                    .findByCollegeAndDepartmentNameIsNull(college)
+                    .orElseThrow(DepartmentAdminNotFoundException::new);
+        }
+
         return departmentRepository
                 .findByCollegeAndDepartmentName(college, departmentName)
                 .orElseThrow(DepartmentAdminNotFoundException::new);


### PR DESCRIPTION
### Motivation
- `college`만 전달하는 경우를 단과대(학부) 레벨로 처리해야 하지만, 기존 호출 경로에서 `department`가 `null`일 때 잘못된 저장/조회 경로로 인해 예외가 발생할 수 있었습니다.
- API 사용자는 `department` 파라미터를 생략해도 단과대 레벨 공지를 생성할 수 있어야 하므로 파라미터와 내부 조회 로직을 보완했습니다.

### Description
- 컨트롤러에서 생성 API의 `department` 요청 파라미터를 선택값으로 변경하여 `@RequestParam(required = false) DepartmentName department`로 수정했습니다.
- 서비스 내부의 `validateAdminAndGetDepartment`에서 `departmentName == null`일 경우 `findByCollegeAndDepartmentNameIsNull(college)`를 호출하도록 분기 처리를 추가했습니다.
- `department`가 제공된 경우 기존과 동일하게 `findByCollegeAndDepartmentName(college, departmentName)` 경로를 사용하도록 유지했습니다.

### Testing
- `./gradlew test --tests "*AdminStudentCouncilNoticeServiceImpl*"`를 실행했으며 빌드 과정에서 JDK/Gradle 호환성 문제(`Unsupported class file major version 69`)로 인해 테스트가 실패했습니다.
- 위 이유로 해당 서비스 레이어 단위 테스트의 실행 검증은 로컬 환경 제약으로 완료하지 못했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa9b9124b883259caf104e504f4ac0)