### PR TITLE
Add trending notices API and per-notice view-count tracking with crawler sync

### DIFF
--- a/docs/NOTICE_TRENDING_API_SPEC.md
+++ b/docs/NOTICE_TRENDING_API_SPEC.md
@@ -1,0 +1,77 @@
+# 공지 조회수/급상승 저장 전략 (권장안)
+
+## 핵심 결론 (정답)
+
+- **둘 다 저장하는 게 맞습니다.**
+  - `viewCount`: 외부 사이트의 "실제 조회수"
+  - `countView`: 오늘 기준 누적 증가량(급상승 계산용)
+- DB를 껐다 켠다고 데이터가 자동 초기화되지는 않습니다.
+  - **영속 DB(MySQL/PostgreSQL 디스크 볼륨)**를 쓰면 그대로 유지됩니다.
+  - 인메모리(H2 memory)나 컨테이너 볼륨 미사용이면 초기화될 수 있습니다.
+
+---
+
+## 왜 2개를 같이 저장해야 하나?
+
+1. `viewCount`만 있으면 현재 인기(절대값)는 보이지만, "오늘 갑자기 뜬" 공지를 잡기 어렵습니다.
+2. `countView`(증가량)를 같이 저장하면 급상승 TOP10을 안정적으로 계산할 수 있습니다.
+3. 클라이언트/운영에서
+   - "실제 조회수"
+   - "오늘 상승폭"
+   을 분리해서 보여줄 수 있습니다.
+
+---
+
+## 이번 적용 정책
+
+### Notice 저장 컬럼
+- `viewCount`: 실제 조회수
+- `viewCountDeltaToday`: 오늘 누적 증가량 (`countView`)
+- `viewCountDeltaDate`: 증가량 기준일
+
+### 크롤링 시 업데이트
+1. 조회수 크롤링
+2. 날짜가 바뀌면 `viewCountDeltaToday`를 0으로 리셋
+3. `(새 조회수 - 이전 조회수)`가 양수면 누적
+4. `viewCount`를 최신값으로 갱신
+
+> 외부 사이트 보정 등으로 조회수가 감소해도 음수는 누적하지 않음.
+
+### 급상승 API 정렬 기준
+- `viewCountDeltaToday DESC`
+- 동률 시 `viewCount DESC`, `date DESC`
+
+---
+
+## DB 재기동/초기화 관련 정리
+
+- **정상 운영 DB**: 서버 재기동/DB 재기동해도 값 유지
+- **초기화되는 경우**:
+  - 인메모리 DB 사용
+  - Docker 볼륨 미마운트
+  - 배포 파이프라인에서 recreate 시 데이터 볼륨 삭제
+
+### 권장 운영
+- MySQL/PostgreSQL + Persistent Volume
+- 정기 백업(스냅샷)
+- 필요 시 조회수 이력 테이블(스냅샷) 추가로 장기 분석
+
+---
+
+## API
+
+### `GET /api/v1/notices/trending?size=10`
+
+```json
+[
+  {
+    "title": "2026학년도 1학기 대학 재학생 등록금 최종 납부 안내",
+    "date": "2026-03-06T00:00:00",
+    "category": "general",
+    "link": "https://www.mju.ac.kr/...",
+    "viewCount": 391,
+    "countView": 124,
+    "countViewDate": "2026-03-07"
+  }
+]
+```

--- a/src/main/java/nova/mjs/domain/thingo/notice/controller/NoticeController.java
+++ b/src/main/java/nova/mjs/domain/thingo/notice/controller/NoticeController.java
@@ -7,6 +7,8 @@ import nova.mjs.domain.thingo.notice.dto.NoticeResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/notices")
@@ -35,6 +37,14 @@ public class NoticeController {
     @PostMapping("/crawl/all")
     public void crawlAll() {
         noticeCrawlingService.fetchAllNotices();
+    }
+
+
+    @GetMapping("/trending")
+    public List<NoticeResponseDto.Trending> getDailyTrendingNotices(
+            @RequestParam(value = "size", defaultValue = "10") int size
+    ) {
+        return noticeService.getDailyTrendingNotices(size);
     }
 
     /**

--- a/src/main/java/nova/mjs/domain/thingo/notice/dto/NoticeResponseDto.java
+++ b/src/main/java/nova/mjs/domain/thingo/notice/dto/NoticeResponseDto.java
@@ -3,73 +3,84 @@ package nova.mjs.domain.thingo.notice.dto;
 import lombok.*;
 import nova.mjs.domain.thingo.notice.entity.Notice;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
  * 공지 응답 DTO
- *
- * - LIST  : 공지 목록 조회용 (가볍고 빠름)
- * - DETAIL: 공지 상세 조회용 (본문 포함)
- *
- * 설계 원칙:
- * 1. 목록 조회 시에는 content를 포함하지 않는다.
- * 2. 상세 조회 시에만 content를 포함한다.
- * 3. DTO 책임은 "응답 형태 정의"까지만 가진다.
  */
 public class NoticeResponseDto {
 
-    /**s
-     * 공지 목록 조회용 DTO
-     */
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Summary {
 
-        private String title;          // 공지 제목
-        private LocalDateTime date;    // 공지 날짜
-        private String category;       // 공지 카테고리
-        private String link;           // 공지 링크
+        private String title;
+        private LocalDateTime date;
+        private String category;
+        private String link;
+        private Integer viewCount;
 
-        /**
-         * Entity → 목록 DTO 변환
-         */
         public static Summary fromEntity(Notice notice) {
             return Summary.builder()
                     .title(notice.getTitle())
                     .date(notice.getDate())
                     .category(notice.getCategory())
                     .link(notice.getLink())
+                    .viewCount(notice.getViewCount())
                     .build();
         }
     }
 
-    /**
-     * 공지 상세 조회용 DTO
-     */
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Detail {
 
-        private String title;          // 공지 제목
-        private LocalDateTime date;    // 공지 날짜
-        private String category;       // 공지 카테고리
-        private String link;           // 공지 링크
-        private String content;        // 공지 본문 (HTML)
+        private String title;
+        private LocalDateTime date;
+        private String category;
+        private String link;
+        private Integer viewCount;
+        private String content;
 
-        /**
-         * Entity → 상세 DTO 변환
-         */
         public static Detail fromEntity(Notice notice) {
             return Detail.builder()
                     .title(notice.getTitle())
                     .date(notice.getDate())
                     .category(notice.getCategory())
                     .link(notice.getLink())
+                    .viewCount(notice.getViewCount())
                     .content(notice.getContent())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Trending {
+        private String title;
+        private LocalDateTime date;
+        private String category;
+        private String link;
+        private Integer viewCount;
+        private Integer countView;
+        private LocalDate countViewDate;
+
+        public static Trending fromEntity(Notice notice) {
+            return Trending.builder()
+                    .title(notice.getTitle())
+                    .date(notice.getDate())
+                    .category(notice.getCategory())
+                    .link(notice.getLink())
+                    .viewCount(notice.getViewCount())
+                    .countView(notice.getViewCountDeltaToday())
+                    .countViewDate(notice.getViewCountDeltaDate())
                     .build();
         }
     }

--- a/src/main/java/nova/mjs/domain/thingo/notice/entity/Notice.java
+++ b/src/main/java/nova/mjs/domain/thingo/notice/entity/Notice.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import nova.mjs.domain.thingo.ElasticSearch.EntityListner.NoticeEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -35,15 +36,47 @@ public class Notice {
     @Column(nullable = false, length = 1000)
     private String link;        // 공지 링크
 
-    public static Notice createNotice(String title, String content, LocalDateTime date, String type, String link) {
+    @Column(nullable = false)
+    private Integer viewCount;  // 공지 실제 조회수(원본 사이트)
+
+    @Column(nullable = false)
+    private Integer viewCountDeltaToday; // 오늘 누적 조회수 증가량(급상승 계산용)
+
+    @Column(nullable = false)
+    private LocalDate viewCountDeltaDate; // 누적 기준일
+
+    public static Notice createNotice(String title, String content, LocalDateTime date, String type, String link, int viewCount) {
+        LocalDate today = LocalDate.now();
         return Notice.builder()
                 .title(title)
                 .content(content)
                 .date(date)
                 .category(type)
                 .link(link)
+                .viewCount(Math.max(0, viewCount))
+                .viewCountDeltaToday(0)
+                .viewCountDeltaDate(today)
                 .build();
     }
 
-}
+    /**
+     * 크롤링한 조회수를 반영한다.
+     * - 날짜가 바뀌면 증가량 카운터를 리셋한다.
+     * - 역전(원본 사이트 보정) 시 음수 증가량은 누적하지 않는다.
+     */
+    public void applyCrawledViewCount(int crawledViewCount, LocalDate crawledDate) {
+        int normalizedCount = Math.max(0, crawledViewCount);
 
+        if (viewCountDeltaDate == null || !viewCountDeltaDate.equals(crawledDate)) {
+            viewCountDeltaDate = crawledDate;
+            viewCountDeltaToday = 0;
+        }
+
+        int diff = normalizedCount - Math.max(0, viewCount == null ? 0 : viewCount);
+        if (diff > 0) {
+            viewCountDeltaToday += diff;
+        }
+
+        viewCount = normalizedCount;
+    }
+}

--- a/src/main/java/nova/mjs/domain/thingo/notice/repository/NoticeRepository.java
+++ b/src/main/java/nova/mjs/domain/thingo/notice/repository/NoticeRepository.java
@@ -9,8 +9,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -56,6 +58,17 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             String title,
             LocalDateTime dateAfter
     );
+
+
+    Optional<Notice> findByCategoryAndLink(String category, String link);
+
+    @Query("""
+        select n
+        from Notice n
+        where n.viewCountDeltaDate = :today
+        order by n.viewCountDeltaToday desc, n.viewCount desc, n.date desc
+    """)
+    List<Notice> findTrendingByTodayDelta(@Param("today") LocalDate today, Pageable pageable);
 
     /**
      * (선택) 최근 범위(예: 1개월) 내에서

--- a/src/main/java/nova/mjs/domain/thingo/notice/service/NoticeCrawlingService.java
+++ b/src/main/java/nova/mjs/domain/thingo/notice/service/NoticeCrawlingService.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -134,6 +135,7 @@ public class NoticeCrawlingService {
          * - DB 저장은 마지막에 한 번만 수행하여 트랜잭션 및 flush 횟수를 줄인다.
          */
         List<Notice> toSave = new ArrayList<>(32);
+        Map<String, Integer> viewCountUpdates = new HashMap<>(64);
 
         /*
          * (선택) 최근 1개월 목록 동기화를 위한 링크 수집.
@@ -158,7 +160,7 @@ public class NoticeCrawlingService {
                 /*
                  * row 처리 결과가 stop이면, 현재 카테고리 크롤링을 즉시 종료한다.
                  */
-                stop = processRow(row, category, cutoffYear, recentThreshold, crawledLinksRecent, toSave);
+                stop = processRow(row, category, cutoffYear, recentThreshold, crawledLinksRecent, toSave, viewCountUpdates);
                 if (stop) {
                     break;
                 }
@@ -173,6 +175,10 @@ public class NoticeCrawlingService {
         applicationContext
                 .getBean(NoticeCrawlingService.class)
                 .saveNotices(toSave);
+
+        applicationContext
+                .getBean(NoticeCrawlingService.class)
+                .syncViewCounts(category, viewCountUpdates);
 
         /*
          * (선택) 최근 1개월 범위 동기화(cleanup)
@@ -206,7 +212,8 @@ public class NoticeCrawlingService {
             int cutoffYear,
             LocalDateTime recentThreshold,
             Set<String> crawledLinksRecent,
-            List<Notice> toSave
+            List<Notice> toSave,
+            Map<String, Integer> viewCountUpdates
     ) {
 
         // (1) 목록 페이지에서 최소한의 메타 정보 추출
@@ -270,6 +277,9 @@ public class NoticeCrawlingService {
          * 처리 방식:
          * - 이 row만 스킵하고 다음 row를 계속 처리한다.
          */
+        int crawledViewCount = NoticeCrawlHelper.crawlViewCount(finalUrl);
+        viewCountUpdates.put(finalUrl, crawledViewCount);
+
         if (noticeRepository.existsByCategoryAndLink(category, finalUrl)) {
             return false;
         }
@@ -333,7 +343,8 @@ public class NoticeCrawlingService {
                         content,
                         date,
                         category,
-                        finalUrl
+                        finalUrl,
+                        crawledViewCount
                 )
         );
 
@@ -353,6 +364,19 @@ public class NoticeCrawlingService {
         if (!notices.isEmpty()) {
             noticeRepository.saveAll(notices);
         }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    protected void syncViewCounts(String category, Map<String, Integer> viewCountUpdates) {
+        if (viewCountUpdates == null || viewCountUpdates.isEmpty()) {
+            return;
+        }
+
+        LocalDate today = LocalDate.now();
+        viewCountUpdates.forEach((link, viewCount) ->
+                noticeRepository.findByCategoryAndLink(category, link)
+                        .ifPresent(notice -> notice.applyCrawledViewCount(viewCount, today))
+        );
     }
 
     /**

--- a/src/main/java/nova/mjs/domain/thingo/notice/service/NoticeService.java
+++ b/src/main/java/nova/mjs/domain/thingo/notice/service/NoticeService.java
@@ -1,7 +1,5 @@
 package nova.mjs.domain.thingo.notice.service;
 
-import java.time.LocalDateTime;
-
 import lombok.RequiredArgsConstructor;
 import nova.mjs.domain.thingo.notice.dto.NoticeResponseDto;
 import nova.mjs.domain.thingo.notice.entity.Notice;
@@ -13,6 +11,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +28,6 @@ public class NoticeService {
             throw new NoticeNotFoundException();
         }
 
-        // category가 null 또는 빈 문자열이면 "all"로 처리
         if (category == null || category.trim().isEmpty()) {
             category = "all";
         }
@@ -35,29 +36,25 @@ public class NoticeService {
 
         Sort.Direction direction = "asc".equalsIgnoreCase(sort) ? Sort.Direction.ASC : Sort.Direction.DESC;
         Pageable pageable = PageRequest.of(
-                Math.max(0, page), // 음수 방어
-                Math.max(1, size), // 최소 1개 보장
+                Math.max(0, page),
+                Math.max(1, size),
                 Sort.by(direction, "date")
         );
-
 
         Page<Notice> notices;
 
         if (year != null) {
-            // 연도 필터 있을 경우
             LocalDateTime startDate = LocalDateTime.of(year, 1, 1, 0, 0);
             LocalDateTime endDate = LocalDateTime.of(year, 12, 31, 23, 59, 59);
 
             notices = isAll
-                    ? noticeRepository.findByDateBetween(startDate, endDate, pageable) // 전체 조회
-                    : noticeRepository.findByCategoryAndDateBetween(category, startDate, endDate, pageable); // 카테고리별 조회
+                    ? noticeRepository.findByDateBetween(startDate, endDate, pageable)
+                    : noticeRepository.findByCategoryAndDateBetween(category, startDate, endDate, pageable);
         } else {
-            // 연도 필터 없을 경우
             notices = isAll
-                    ? noticeRepository.findAll(pageable) // 전체 조회
-                    : noticeRepository.findByCategory(category, pageable); // 카테고리별 조회
+                    ? noticeRepository.findAll(pageable)
+                    : noticeRepository.findByCategory(category, pageable);
         }
-
 
         if (notices.isEmpty()) {
             throw new NoticeNotFoundException();
@@ -65,5 +62,14 @@ public class NoticeService {
 
         return notices.map(NoticeResponseDto.Summary::fromEntity);
 
+    }
+
+    public List<NoticeResponseDto.Trending> getDailyTrendingNotices(int size) {
+        Pageable pageable = PageRequest.of(0, Math.max(1, size));
+
+        return noticeRepository.findTrendingByTodayDelta(LocalDate.now(), pageable)
+                .stream()
+                .map(NoticeResponseDto.Trending::fromEntity)
+                .toList();
     }
 }

--- a/src/main/java/nova/mjs/domain/thingo/notice/service/crawl/NoticeCrawlHelper.java
+++ b/src/main/java/nova/mjs/domain/thingo/notice/service/crawl/NoticeCrawlHelper.java
@@ -6,6 +6,9 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * 공지 크롤링 기술 로직 전담 Helper
  * - 목록 페이지 크롤링
@@ -18,6 +21,8 @@ import org.jsoup.select.Elements;
 public class NoticeCrawlHelper {
 
     private static final String BASE_URL = "https://www.mju.ac.kr/";
+
+    private static final Pattern VIEW_COUNT_PATTERN = Pattern.compile("조회수\\s*(\\d+)");
 
     /**
      * 공지 목록 페이지 크롤링
@@ -34,6 +39,33 @@ public class NoticeCrawlHelper {
             return doc.select("tr:not(.headline):not(._artclOdd)");
         } catch (Exception e) {
             throw new IllegalStateException("목록 페이지 크롤링 실패: " + fullUrl, e);
+        }
+    }
+
+
+    /**
+     * 공지 상세 페이지 조회수 파싱
+     * @param link 상세 페이지 URL
+     * @return 조회수 (실패 시 0)
+     */
+    public static int crawlViewCount(String link) {
+        try {
+            Document doc = Jsoup.connect(link).get();
+            Element headInfo = doc.selectFirst("div.head_info");
+            if (headInfo == null) {
+                return 0;
+            }
+
+            String text = headInfo.text();
+            Matcher matcher = VIEW_COUNT_PATTERN.matcher(text);
+            if (matcher.find()) {
+                return Integer.parseInt(matcher.group(1));
+            }
+
+            return 0;
+        } catch (Exception e) {
+            log.warn("[MJS] view count crawling failed. link={}", link, e);
+            return 0;
         }
     }
 

--- a/src/main/resources/static/openapi/campus.json
+++ b/src/main/resources/static/openapi/campus.json
@@ -600,6 +600,36 @@
         }
       }
     },
+    "/notices/trending": {
+      "get": {
+        "tags": ["Notice"],
+        "summary": "공지사항 급상승 조회(1일)",
+        "description": "오늘 기준 누적 조회수 증가량(countView) 순서로 급상승 공지를 조회합니다.",
+        "parameters": [
+          {
+            "name": "size",
+            "in": "query",
+            "schema": { "type": "integer", "default": 10, "minimum": 1 },
+            "description": "조회할 최대 공지 수"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "급상승 공지 목록 반환",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TrendingNoticeItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
   "/calendar": {
     "get": {
       "tags": ["MJU_Calendar"],
@@ -1143,7 +1173,8 @@
                 "title": { "type": "string" },
                 "date": { "type": "string" },
                 "category": { "type": "string" },
-                "link": { "type": "string", "format": "uri" }
+                "link": { "type": "string", "format": "uri" },
+                "viewCount": { "type": "integer", "description": "공지 조회수" }
               }
             }
           },
@@ -1171,6 +1202,18 @@
           "first": { "type": "boolean" },
           "numberOfElements": { "type": "integer" },
           "empty": { "type": "boolean" }
+        }
+      },
+      "TrendingNoticeItem": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "date": { "type": "string" },
+          "category": { "type": "string" },
+          "link": { "type": "string", "format": "uri" },
+          "viewCount": { "type": "integer" },
+          "countView": { "type": "integer", "description": "오늘 누적 조회수 증가량" },
+          "countViewDate": { "type": "string", "format": "date", "description": "countView 집계 기준일" }
         }
       },
       "NewsItem": {


### PR DESCRIPTION
### Motivation

- Expose a daily "trending" API based on per-day view increases and persist per-notice view metadata to enable reliable "today spike" ranking and client display.
- Record both the absolute external `viewCount` and a daily-increment `viewCountDeltaToday` with a reference date to survive restarts and handle refcount corrections.

### Description

- Added new persistent fields to `Notice`: `viewCount`, `viewCountDeltaToday`, and `viewCountDeltaDate`, and implemented `applyCrawledViewCount` to update these safely when crawling results arrive.
- Updated `Notice.createNotice` signature to accept an initial `viewCount`, and included `viewCount` in `Summary` and `Detail` DTOs, plus added a new `Trending` DTO mapping `countView` and `countViewDate` from the entity.
- Implemented crawling of per-notice view counts in `NoticeCrawlHelper.crawlViewCount` and wired collection/sync of crawled counts in `NoticeCrawlingService` via a `viewCountUpdates` buffer and `syncViewCounts` transactional method; `processRow` now fetches crawled view count and passes it into created entities.
- Exposed `GET /api/v1/notices/trending` in `NoticeController` and added repository query `findTrendingByTodayDelta` to return items ordered by `viewCountDeltaToday DESC` (tie-breaker `viewCount DESC`, `date DESC`); OpenAPI spec and a new docs file `docs/NOTICE_TRENDING_API_SPEC.md` were added/updated.

### Testing

- Ran the existing automated test suite with `mvn test` and the suite completed successfully without new test failures.
- No new automated tests were added for the trending feature in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad5bfb41908325869ecdfd0105d58e)