### PR TITLE
docs: update map search OpenAPI spec

### DIFF
--- a/src/main/resources/static/openapi/map.json
+++ b/src/main/resources/static/openapi/map.json
@@ -222,30 +222,39 @@
         "tags": ["명지도 - 검색"],
         "summary": "명지도 검색 (건물/장소)",
         "operationId": "searchMap",
-        "description": "명지도 전용 검색입니다. 기존 통합검색(/search)과 별개로, 캠퍼스 건물/장소만 대상으로 합니다.\n\n### 사용 시나리오\n1. 검색창 진입 후 검색어 입력 (단어 형식)\n2. (선택) 기기 GPS 좌표(lat/lng) 함께 전달\n3. 결과 카드 목록 렌더 + 지도에 핀 표시\n4. 카드 클릭 시 `type`으로 상세 분기: `BUILDING`→건물 상세(`/map/buildings/{id}`), `PLACE`→장소 상세(`/map/places/{id}`)\n\n### 무엇을 검색하나\n- **건물/장소명**과 **카테고리명**을 함께 매칭합니다.\n\n### 검색 품질 (자동 처리)\n| 기능 | 예시 |\n|------|------|\n| 공백/기호 무시 | `투썸 플레이스` = `투썸플레이스` |\n| 부분 일치 | `종합` → 종합관 |\n| 초성 검색 | `ㅌㅆ` → 투썸플레이스 |\n| 오타 허용 | `투썹` → 투썸플레이스 |\n| 대소문자 무시 | `gs25` = `GS25` |\n\n### 정렬\n- **관련도 우선** → 동점 시 **가까운 순** → 이름순\n- 캠퍼스 반경(약 500m) 밖이면 거리는 미표시(정렬만 정문 기준), GPS 없으면 거리 null\n\n### 종류 필터\n- `type=BUILDING` 또는 `type=PLACE`로 건물/장소만 필터링. 생략 시 전체. 잘못된 값은 전체로 처리\n\n### 페이지네이션 (무한 스크롤)\n- `page`/`size`로 잘라 반환. 반환 개수가 `size`보다 작으면 마지막 페이지\n\n### 결과 카드(PinSummary) 주의\n- `operatingStatus`: 건물은 자기 운영시간, 내부 장소는 소속 건물 운영시간 상속, 외부 장소는 null. '운영 종료'면 다음 오픈 안내가 붙습니다 (예: `운영 종료 (내일 09:00 오픈)`)\n- `location`: 내부 장소는 '건물명 + 층수', 외부 장소는 도로명 주소 (프론트에서 최대 65자, 초과 시 생략 표시)\n- `distanceMeters`: 캠퍼스 안에서 GPS가 있을 때만. 그 외 null(미표시)",
+        "description": "명지도 전용 검색입니다. 응답 최상단 `resultType`은 배열 전체의 화면 종류를 나타내며 한 응답 안에서 섞이지 않습니다.\n\n### 분기 우선순위\n1. 정확한 실내 title/호실 코드: `FLOOR_MAP` — `{id,name,link}` 한 건\n2. 등록된 명지도 라벨 정확 일치: `LABEL` — 기존 `/map/categories/{code}/pins`와 동일한 목록\n3. 그 외: `GENERAL` — 기존 건물/장소 검색 목록\n\n`카페`, `프린터`, `대동명지도`처럼 라벨과 정확히 일치하면 장소명 검색 결과가 있어도 `LABEL`을 우선합니다. `type=BUILDING|PLACE` 필터는 `GENERAL` 검색에만 적용됩니다.\n\n### 검색 품질\n- 일반 검색은 공백/기호 무시, 부분 일치, 초성, 오타 허용을 지원합니다.\n- `FLOOR_MAP`은 정확 일치만 허용합니다.\n\n### 페이지네이션\n- `LABEL`과 `GENERAL`은 `page`/`size`를 사용합니다. `FLOOR_MAP`은 첫 페이지에 한 건만 반환합니다.",
         "parameters": [
           { "name": "keyword", "in": "query", "required": true, "description": "검색어 (건물/장소명 또는 카테고리명, 초성/오타 허용). 비면 빈 목록", "schema": { "type": "string", "example": "투썸" } },
           { "name": "type", "in": "query", "required": false, "description": "종류 필터. 생략 시 전체", "schema": { "type": "string", "enum": ["BUILDING", "PLACE"], "example": "PLACE" } },
           { "name": "lat", "in": "query", "required": false, "description": "사용자 현재 위도 (프론트 GPS). 없으면 거리 미계산", "schema": { "type": "number", "format": "double", "example": 37.5802 } },
           { "name": "lng", "in": "query", "required": false, "description": "사용자 현재 경도 (프론트 GPS)", "schema": { "type": "number", "format": "double", "example": 126.9226 } },
           { "name": "page", "in": "query", "required": false, "description": "0부터 시작하는 페이지 번호", "schema": { "type": "integer", "default": 0, "example": 0 } },
-          { "name": "size", "in": "query", "required": false, "description": "페이지 크기", "schema": { "type": "integer", "default": 20, "example": 20 } }
+          { "name": "size", "in": "query", "required": false, "description": "페이지 크기", "schema": { "type": "integer", "default": 20, "example": 20 } },
+          { "name": "seed", "in": "query", "required": false, "description": "대동명지도 추천 순서를 세션 동안 고정할 seed", "schema": { "type": "string" } }
         ],
         "responses": {
           "200": {
-            "description": "검색 결과 카드 목록 (관련도 순)",
+            "description": "검색 결과. resultType에 따라 data 항목 스키마가 결정됩니다.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
                     "status": { "type": "string", "example": "API 요청 성공" },
-                    "data": { "type": "array", "items": { "$ref": "#/components/schemas/PinSummary" } },
+                    "resultType": { "type": "string", "enum": ["FLOOR_MAP", "LABEL", "GENERAL"] },
+                    "data": {
+                      "oneOf": [
+                        { "type": "array", "items": { "$ref": "#/components/schemas/FloorMapSearchItem" } },
+                        { "type": "array", "items": { "$ref": "#/components/schemas/PinSummary" } }
+                      ]
+                    },
                     "timestamp": { "type": "string", "format": "date-time", "example": "2026-07-02T09:05:12" }
-                  }
+                  },
+                  "required": ["status", "resultType", "data", "timestamp"]
                 },
                 "example": {
                   "status": "API 요청 성공",
+                  "resultType": "GENERAL",
                   "data": [
                     { "id": 51, "type": "PLACE", "name": "투썸플레이스 명지대점", "categoryCode": "cafe", "iconKey": "CafeIcon", "imageUrl": "https://thingo.kr/img/place/51.jpg", "classroomCode": null, "location": "서울 서대문구 거북골로 31-1 1~3층", "favorite": false, "operatingStatus": null, "distanceMeters": 720, "latitude": 37.5806, "longitude": 126.9231 },
                     { "id": 1, "type": "BUILDING", "name": "종합관", "categoryCode": "building", "iconKey": "BuildingIcon", "imageUrl": "https://thingo.kr/img/building/1.jpg", "classroomCode": "S1XXX", "location": null, "favorite": false, "operatingStatus": "운영중", "distanceMeters": 80, "latitude": 37.5803, "longitude": 126.9223 }
@@ -658,8 +667,19 @@
           "infoText": { "type": "string", "nullable": true },
           "address": { "type": "string", "nullable": true, "description": "외부 장소 도로명 주소", "example": "서울 서대문구 거북골로 25-8" },
           "parentBuildingCode": { "type": "string", "nullable": true, "description": "내부 장소면 소속 건물 코드" },
-          "floorLabel": { "type": "string", "nullable": true, "description": "내부 장소면 소속 층 라벨" }
+          "floorLabel": { "type": "string", "nullable": true, "description": "내부 장소면 소속 층 라벨" },
+          "indoorCode": { "type": "string", "nullable": true, "description": "검색 가능한 실제 호실/요소 코드. 입력 시 소속 건물과 층 필수", "example": "S1353" }
         }
+      },
+      "FloorMapSearchItem": {
+        "type": "object",
+        "description": "정확한 실내 title 검색 결과. 프론트는 link로 그대로 이동한다.",
+        "properties": {
+          "id": { "type": "integer", "format": "int64", "example": 353 },
+          "name": { "type": "string", "example": "강의실 S1353" },
+          "link": { "type": "string", "example": "/maps/floor?buildingId=2&floorLabel=F4&target=S1353" }
+        },
+        "required": ["id", "name", "link"]
       },
       "SyncOperatingHourRow": {
         "type": "object",
@@ -691,7 +711,8 @@
           "operatingStatus": { "type": "string", "nullable": true, "description": "운영 상태 한글 라벨. 기본값: '곧 운영 시작' / '운영중' / '곧 운영 종료' / '운영 종료' / '24시간 운영' / '휴무'. 검색(/map/search) 결과에서는 '운영 종료'에 다음 오픈 안내가 붙는다(예: '운영 종료 (내일 09:00 오픈)'). 건물은 자기 운영시간, 검색 결과의 내부 장소는 소속 건물 운영시간을 상속. 외부 장소/운영시간 없으면 null", "example": "운영중" },
           "distanceMeters": { "type": "integer", "nullable": true, "description": "현재 위치로부터 거리(미터). 캠퍼스 밖/GPS 없으면 null(미표시)", "example": 150 },
           "latitude": { "type": "number", "format": "double", "nullable": true, "description": "지도 마커용 위도. 내부 장소는 소속 건물 좌표. 좌표 없으면 null", "example": 37.5796415 },
-          "longitude": { "type": "number", "format": "double", "nullable": true, "description": "지도 마커용 경도. 내부 장소는 소속 건물 좌표. 좌표 없으면 null", "example": 126.9250425 }
+          "longitude": { "type": "number", "format": "double", "nullable": true, "description": "지도 마커용 경도. 내부 장소는 소속 건물 좌표. 좌표 없으면 null", "example": 126.9250425 },
+          "indoorCode": { "type": "string", "nullable": true, "description": "검색 가능한 실제 호실/요소 코드", "example": "S1353" }
         },
         "required": ["id", "type", "name", "categoryCode", "favorite"]
       },
@@ -703,7 +724,8 @@
           "name": { "type": "string", "description": "건물명/장소명", "example": "투썸플레이스 명지대점" },
           "type": { "type": "string", "description": "종류. 프론트가 상세 화면을 분기", "enum": ["BUILDING", "PLACE"], "example": "PLACE" },
           "categoryCode": { "type": "string", "description": "소속 카테고리 코드", "example": "cafe" },
-          "iconKey": { "type": "string", "description": "아이콘 키 (카테고리 아이콘)", "example": "CafeIcon" }
+          "iconKey": { "type": "string", "description": "아이콘 키 (카테고리 아이콘)", "example": "CafeIcon" },
+          "indoorCode": { "type": "string", "nullable": true, "example": "S1353" }
         },
         "required": ["id", "name", "type", "categoryCode"]
       },
@@ -735,7 +757,8 @@
           "id": { "type": "integer", "format": "int64", "example": 120 },
           "name": { "type": "string", "example": "무한 프린터" },
           "categoryCode": { "type": "string", "example": "printer" },
-          "iconKey": { "type": "string", "example": "PrinterIcon" }
+          "iconKey": { "type": "string", "example": "PrinterIcon" },
+          "indoorCode": { "type": "string", "nullable": true, "example": "S1353" }
         },
         "required": ["id", "name", "categoryCode"]
       },


### PR DESCRIPTION
## 변경 사항
- 명지도 검색 응답의 `resultType` 분기(`FLOOR_MAP`, `LABEL`, `GENERAL`)를 명세에 반영했습니다.
- 정확한 실내 장소 검색 결과와 층별 안내도 이동 링크 스키마를 추가했습니다.
- 추천 순서 고정을 위한 `seed` 파라미터와 `indoorCode` 응답 필드를 문서화했습니다.

## 영향
- 실행 코드 변경 없이 `src/main/resources/static/openapi/map.json`만 변경합니다.
- 프론트엔드는 `resultType`에 따라 결과 스키마와 이동 화면을 분기할 수 있습니다.

## 검증
- 최신 로컬 컨트롤러/DTO와 명세 필드를 대조했습니다.
- `map.json` JSON 파싱 검증을 통과했습니다.