### PR TITLE
feat: route map searches by result type

### DIFF
--- a/src/main/java/nova/mjs/domain/thingo/map/controller/MapSearchController.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/controller/MapSearchController.java
@@ -3,8 +3,7 @@ package nova.mjs.domain.thingo.map.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nova.mjs.domain.thingo.map.dto.MapSuggestResponse;
-import nova.mjs.domain.thingo.map.dto.PinSummaryResponse;
-import nova.mjs.domain.thingo.map.entity.PinType;
+import nova.mjs.domain.thingo.map.dto.MapSearchResponse;
 import nova.mjs.domain.thingo.map.service.MapSearchService;
 import nova.mjs.util.response.ApiResponse;
 import nova.mjs.util.security.UserPrincipal;
@@ -23,8 +22,7 @@ import java.util.List;
  * 2. GET /api/v1/map/search/suggest   - 검색 자동완성 (경량)
  *
  * [공통 파라미터]
- * - keyword: 검색어 (건물/장소명 + 카테고리명 매칭, 초성/오타 허용)
- * - type: 종류 필터 (BUILDING/PLACE). 없으면 전체. 잘못된 값도 전체로 처리
+ * - keyword: 검색어 (실내 title 정확일치 → 라벨 정확일치 → 일반 이름 검색 순으로 판정)
  * - lat/lng: 프론트 GPS 좌표. 거리 계산/정렬에만 쓰고 저장하지 않는다
  *
  * [인증]
@@ -39,24 +37,23 @@ public class MapSearchController {
     private final MapSearchService mapSearchService;
 
     /**
-     * 명지도 검색 결과 목록 조회 (무한 스크롤).
-     * 반환 개수가 size보다 작으면 마지막 페이지다.
+     * 명지도 검색 결과 조회.
+     * 응답의 resultType은 data 배열 전체에 적용되며 FLOOR_MAP/LABEL/GENERAL 중 하나다.
      */
     @GetMapping("/search")
-    public ApiResponse<List<PinSummaryResponse>> search(
+    public MapSearchResponse search(
             @RequestParam("keyword") String keyword,
-            @RequestParam(value = "type", required = false) String type,
             @RequestParam(value = "lat", required = false) Double lat,
             @RequestParam(value = "lng", required = false) Double lng,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "20") int size,
+            @RequestParam(value = "seed", required = false) String seed,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
         String email = (userPrincipal != null) ? userPrincipal.getUsername() : null;
-        PinType typeFilter = parseType(type);
-        log.info("[명지도 검색] keyword={}, type={}, lat={}, lng={}, page={}, email={}",
-                keyword, typeFilter, lat, lng, page, email);
-        return ApiResponse.success(mapSearchService.search(keyword, typeFilter, lat, lng, page, size, email));
+        log.info("[명지도 검색] keyword={}, lat={}, lng={}, page={}, email={}",
+                keyword, lat, lng, page, email);
+        return mapSearchService.search(keyword, lat, lng, page, size, email, seed);
     }
 
     /**
@@ -65,22 +62,9 @@ public class MapSearchController {
     @GetMapping("/search/suggest")
     public ApiResponse<List<MapSuggestResponse>> suggest(
             @RequestParam("keyword") String keyword,
-            @RequestParam(value = "type", required = false) String type,
             @RequestParam(value = "limit", defaultValue = "10") int limit
     ) {
-        log.info("[명지도 자동완성] keyword={}, type={}, limit={}", keyword, type, limit);
-        return ApiResponse.success(mapSearchService.suggest(keyword, parseType(type), limit));
-    }
-
-    /** type 파라미터를 PinType으로 파싱. 비었거나 잘못된 값이면 null(전체) */
-    private PinType parseType(String type) {
-        if (type == null || type.isBlank()) {
-            return null;
-        }
-        try {
-            return PinType.valueOf(type.trim().toUpperCase());
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
+        log.info("[명지도 자동완성] keyword={}, limit={}", keyword, limit);
+        return ApiResponse.success(mapSearchService.suggest(keyword, limit));
     }
 }

--- a/src/main/java/nova/mjs/domain/thingo/map/dto/BuildingDetailResponse.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/dto/BuildingDetailResponse.java
@@ -115,6 +115,8 @@ public class BuildingDetailResponse {
         private final String name;
         private final String categoryCode;
         private final String iconKey;
+        /** 실제 호실/요소 코드 (예: S1353) */
+        private final String indoorCode;
 
         public static PlaceBrief from(Pin place) {
             return PlaceBrief.builder()
@@ -122,6 +124,7 @@ public class BuildingDetailResponse {
                     .name(place.getName())
                     .categoryCode(place.getCategory().getCode())
                     .iconKey(place.getCategory().getIconKey())
+                    .indoorCode(place.getIndoorCode())
                     .build();
         }
     }

--- a/src/main/java/nova/mjs/domain/thingo/map/dto/FloorMapSearchItemResponse.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/dto/FloorMapSearchItemResponse.java
@@ -1,0 +1,36 @@
+package nova.mjs.domain.thingo.map.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import nova.mjs.domain.thingo.map.entity.Pin;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/** 정확한 실내 title 검색 결과. 프론트는 link로 그대로 이동한다. */
+@Getter
+@Builder
+public class FloorMapSearchItemResponse {
+
+    private final Long id;
+    private final String name;
+    private final String link;
+
+    public static FloorMapSearchItemResponse from(Pin pin) {
+        if (pin == null || !pin.isInsideBuilding() || pin.getFloor() == null
+                || pin.getIndoorCode() == null || pin.getIndoorCode().isBlank()) {
+            throw new IllegalArgumentException("층별 안내도 검색 결과를 만들 수 없는 핀입니다.");
+        }
+
+        String link = UriComponentsBuilder.fromPath("/maps/floor")
+                .queryParam("buildingId", pin.getParentBuilding().getId())
+                .queryParam("floorLabel", pin.getFloor().getLabel())
+                .queryParam("target", pin.getIndoorCode())
+                .encode()
+                .toUriString();
+
+        return FloorMapSearchItemResponse.builder()
+                .id(pin.getId())
+                .name(pin.getName())
+                .link(link)
+                .build();
+    }
+}

--- a/src/main/java/nova/mjs/domain/thingo/map/dto/MapSearchResponse.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/dto/MapSearchResponse.java
@@ -1,0 +1,28 @@
+package nova.mjs.domain.thingo.map.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 명지도 검색 전용 응답.
+ *
+ * resultType이 data 배열 전체의 스키마와 화면 이동 방식을 결정한다.
+ * 공통 ApiResponse에 필드를 추가하지 않아 다른 API의 응답 계약은 변경하지 않는다.
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MapSearchResponse {
+
+    private final String status;
+    private final MapSearchResultType resultType;
+    private final List<?> data;
+    private final LocalDateTime timestamp;
+
+    public static MapSearchResponse success(MapSearchResultType resultType, List<?> data) {
+        return new MapSearchResponse("API 요청 성공", resultType, data, LocalDateTime.now());
+    }
+}

--- a/src/main/java/nova/mjs/domain/thingo/map/dto/MapSearchResultType.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/dto/MapSearchResultType.java
@@ -1,0 +1,8 @@
+package nova.mjs.domain.thingo.map.dto;
+
+/** 명지도 검색 결과 전체가 어떤 화면으로 이어지는지 나타낸다. */
+public enum MapSearchResultType {
+    FLOOR_MAP,
+    LABEL,
+    GENERAL
+}

--- a/src/main/java/nova/mjs/domain/thingo/map/dto/MapSuggestResponse.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/dto/MapSuggestResponse.java
@@ -24,6 +24,8 @@ public class MapSuggestResponse {
     private final String categoryCode;
     /** 카드 아이콘 키 (카테고리 아이콘) */
     private final String iconKey;
+    /** 실제 호실/요소 코드 (예: S1353). 없으면 null */
+    private final String indoorCode;
 
     public static MapSuggestResponse from(Pin pin) {
         return MapSuggestResponse.builder()
@@ -32,6 +34,7 @@ public class MapSuggestResponse {
                 .type(pin.getType().name())
                 .categoryCode(pin.getCategory().getCode())
                 .iconKey(pin.getCategory().getIconKey())
+                .indoorCode(pin.getIndoorCode())
                 .build();
     }
 }

--- a/src/main/java/nova/mjs/domain/thingo/map/dto/MapSyncDTO.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/dto/MapSyncDTO.java
@@ -96,6 +96,8 @@ public class MapSyncDTO {
         private String parentBuildingCode;
         /** 내부 장소면 소속 층 라벨(건물의 floors와 매칭), 외부 장소면 비움 */
         private String floorLabel;
+        /** 검색 가능한 실제 호실/요소 코드. 예: S1353 */
+        private String indoorCode;
     }
 
     /** operating_hours 탭 1행 (건물 코드 + 요일로 식별) */

--- a/src/main/java/nova/mjs/domain/thingo/map/dto/PinSummaryResponse.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/dto/PinSummaryResponse.java
@@ -41,11 +41,14 @@ public class PinSummaryResponse {
     private final Double latitude;
     /** 지도 마커용 경도. 내부 장소는 소속 건물 좌표로 대체. 좌표 없으면 null */
     private final Double longitude;
+    /** 검색 가능한 실제 호실/요소 코드 (예: S1353). 없으면 null */
+    private final String indoorCode;
 
     public static PinSummaryResponse of(Long id, String type, String name, String categoryCode,
                                         String iconKey, String imageUrl, String classroomCode,
                                         String location, boolean favorite, String operatingStatus,
-                                        Integer distanceMeters, Double latitude, Double longitude) {
+                                        Integer distanceMeters, Double latitude, Double longitude,
+                                        String indoorCode) {
         return PinSummaryResponse.builder()
                 .id(id)
                 .type(type)
@@ -60,6 +63,7 @@ public class PinSummaryResponse {
                 .distanceMeters(distanceMeters)
                 .latitude(latitude)
                 .longitude(longitude)
+                .indoorCode(indoorCode)
                 .build();
     }
 }

--- a/src/main/java/nova/mjs/domain/thingo/map/entity/Pin.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/entity/Pin.java
@@ -31,10 +31,10 @@ import java.util.List;
 @Entity
 @Table(
         name = "map_pin",
-        uniqueConstraints = @UniqueConstraint(
-                name = "uk_map_pin_code",
-                columnNames = "code"
-        )
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_map_pin_code", columnNames = "code"),
+                @UniqueConstraint(name = "uk_map_pin_indoor_code", columnNames = "indoor_code")
+        }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -105,6 +105,13 @@ public class Pin extends BaseEntity {
     @JoinColumn(name = "floor_id")
     private Floor floor;
 
+    /**
+     * 층 안내도에서 검색할 실제 호실/요소 코드 (예: S1353).
+     * 건물의 classroomCode(S1XXX)는 코드 체계 안내용이고, 이 값은 특정 위치를 가리키는 실제 코드다.
+     */
+    @Column(name = "indoor_code")
+    private String indoorCode;
+
     // ===== 연관 (건물 기준) =====
 
     /** 건물에 속한 층 목록 (건물이 아닐 경우 빈 리스트) */
@@ -118,7 +125,7 @@ public class Pin extends BaseEntity {
     @Builder(access = AccessLevel.PRIVATE)
     private Pin(String code, PinType type, Category category, String name, Double latitude, Double longitude,
                String imageUrl, String infoText, Integer buildingNumber, String classroomCode,
-               String address, Pin parentBuilding, Floor floor) {
+               String address, Pin parentBuilding, Floor floor, String indoorCode) {
         this.code = code;
         this.type = type;
         this.category = category;
@@ -132,6 +139,7 @@ public class Pin extends BaseEntity {
         this.address = address;
         this.parentBuilding = parentBuilding;
         this.floor = floor;
+        this.indoorCode = indoorCode;
     }
 
     /**
@@ -175,7 +183,7 @@ public class Pin extends BaseEntity {
      * 건물 내부 장소 핀 생성 (프린터/라운지 등). 좌표는 소속 건물을 따르므로 받지 않는다.
      */
     public static Pin ofInternalPlace(String code, Category category, String name, String imageUrl, String infoText,
-                                      Pin parentBuilding, Floor floor) {
+                                      Pin parentBuilding, Floor floor, String indoorCode) {
         return Pin.builder()
                 .code(code)
                 .type(PinType.PLACE)
@@ -185,6 +193,7 @@ public class Pin extends BaseEntity {
                 .infoText(infoText)
                 .parentBuilding(parentBuilding)
                 .floor(floor)
+                .indoorCode(indoorCode)
                 .build();
     }
 
@@ -194,7 +203,7 @@ public class Pin extends BaseEntity {
      */
     public void update(Category category, String name, Double latitude, Double longitude,
                        String imageUrl, String infoText, Integer buildingNumber, String classroomCode,
-                       String address, Pin parentBuilding, Floor floor) {
+                       String address, Pin parentBuilding, Floor floor, String indoorCode) {
         this.category = category;
         this.name = name;
         this.latitude = latitude;
@@ -206,6 +215,7 @@ public class Pin extends BaseEntity {
         this.address = address;
         this.parentBuilding = parentBuilding;
         this.floor = floor;
+        this.indoorCode = indoorCode;
     }
 
     /** 거리 계산에 쓸 위도. 내부 장소면 소속 건물 위도로 대체. 둘 다 없으면 null */

--- a/src/main/java/nova/mjs/domain/thingo/map/repository/PinRepository.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/repository/PinRepository.java
@@ -31,6 +31,11 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
     /** 동기화 upsert용 - code로 단건 조회 */
     Optional<Pin> findByCode(String code);
 
+    /** 일반 검색에서 S1353 같은 실제 호실 코드를 정확히 찾을 때 사용 */
+    @Query("select p from Pin p join fetch p.category left join fetch p.parentBuilding "
+            + "left join fetch p.floor where lower(p.indoorCode) = lower(:indoorCode)")
+    Optional<Pin> findByIndoorCodeIgnoreCase(@Param("indoorCode") String indoorCode);
+
     /**
      * 리뷰 도메인 등 타 도메인이 카테고리/그룹까지 즉시 필요할 때 쓰는 단건 조회.
      * (리뷰 작성 시 type/카테고리 코드/그룹 코드(F&B 판정)를 트랜잭션 밖에서도 안전하게 접근)

--- a/src/main/java/nova/mjs/domain/thingo/map/service/MapPinService.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/service/MapPinService.java
@@ -278,7 +278,8 @@ public class MapPinService {
                 pin.getType() == PinType.BUILDING ? statusLabel(pin, now) : null, // 운영 상태는 건물에만
                 displayDistance,
                 pin.resolveLatitude(),   // 내부 장소는 소속 건물 좌표로 대체
-                pin.resolveLongitude());
+                pin.resolveLongitude(),
+                pin.getIndoorCode());
     }
 
     /** 화면에 표시할 거리(미터). 캠퍼스 안일 때만 계산, 그 외 null */

--- a/src/main/java/nova/mjs/domain/thingo/map/service/MapSearchService.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/service/MapSearchService.java
@@ -2,13 +2,18 @@ package nova.mjs.domain.thingo.map.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import nova.mjs.domain.thingo.map.dto.FloorMapSearchItemResponse;
 import nova.mjs.domain.thingo.map.dto.MapSuggestResponse;
+import nova.mjs.domain.thingo.map.dto.MapSearchResponse;
+import nova.mjs.domain.thingo.map.dto.MapSearchResultType;
 import nova.mjs.domain.thingo.map.dto.PinSummaryResponse;
+import nova.mjs.domain.thingo.map.entity.Category;
 import nova.mjs.domain.thingo.map.entity.OperatingHour;
 import nova.mjs.domain.thingo.map.entity.Pin;
 import nova.mjs.domain.thingo.map.entity.PinType;
 import nova.mjs.domain.thingo.map.repository.PinFavoriteRepository;
 import nova.mjs.domain.thingo.map.repository.PinRepository;
+import nova.mjs.domain.thingo.map.repository.CategoryRepository;
 import nova.mjs.domain.thingo.map.support.CampusArea;
 import nova.mjs.domain.thingo.map.support.DistanceCalculator;
 import nova.mjs.domain.thingo.map.support.MapSearchMatcher;
@@ -34,7 +39,8 @@ import java.util.Set;
  * (거리 계산을 인메모리 Haversine으로 하는 것과 동일한 판단).
  *
  * [검색 규칙]
- * - 매칭/관련도: {@link MapSearchMatcher} (정규화·초성·오타허용·카테고리 보조)
+ * - 분기: 실내 title 정확일치 → 카테고리 라벨 정확일치 → 일반 이름 검색
+ * - 일반 매칭/관련도: {@link MapSearchMatcher} (정규화·초성·오타허용)
  * - 정렬: 관련도 우선 → 동점 시 가까운 순 → 이름순
  * - 거리: 사용자가 캠퍼스 안이면 표시, 밖이면 미표시(정렬만 정문 기준), GPS 없으면 null
  * - 운영상태: 건물은 자기 운영시간, 내부 장소는 소속 건물 운영시간 상속, 외부 장소는 미표시
@@ -48,31 +54,55 @@ public class MapSearchService {
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final PinRepository pinRepository;
+    private final CategoryRepository categoryRepository;
     private final PinFavoriteRepository pinFavoriteRepository;
     private final MemberRepository memberRepository;
     private final DistanceCalculator distanceCalculator;
     private final OperatingStatusResolver operatingStatusResolver;
     private final MapSearchMatcher matcher;
+    private final MapPinService mapPinService;
 
     /** 관련도 정렬 계산용 임시 행 (핀 + 관련도 점수 + 정렬 거리) */
     private record Scored(Pin pin, double relevance, Double sortDistance) {}
 
     /**
-     * 명지도 검색. 이름·카테고리명에 대해 관련도 점수를 매겨 정렬한 뒤 페이지로 잘라 반환한다.
+     * 명지도 검색. 먼저 응답 전체의 종류를 정한 뒤 종류에 맞는 단일 스키마의 배열을 반환한다.
      *
      * @param keyword    검색어 (비면 빈 목록)
-     * @param typeFilter 종류 필터 (BUILDING/PLACE, null이면 전체)
      * @param userLat    사용자 현재 위도 (거리 계산/정렬용, 없으면 null)
      * @param userLng    사용자 현재 경도
      * @param page       0부터 시작하는 페이지 번호
      * @param size       페이지 크기
      * @param email      로그인 회원 이메일 (즐겨찾기 표시용, 비로그인 null)
+     * @param recommendationSeed 대동명지도 추천 순서를 고정할 선택 seed
      */
-    public List<PinSummaryResponse> search(String keyword, PinType typeFilter,
-                                           Double userLat, Double userLng, int page, int size, String email) {
+    public MapSearchResponse search(String keyword, Double userLat, Double userLng, int page, int size,
+                                    String email, String recommendationSeed) {
         if (keyword == null || keyword.isBlank()) {
-            return List.of();
+            return MapSearchResponse.success(MapSearchResultType.GENERAL, List.of());
         }
+
+        Pin exactIndoorPin = findExactIndoorPin(keyword);
+        if (exactIndoorPin != null) {
+            List<FloorMapSearchItemResponse> data = page <= 0
+                    ? List.of(FloorMapSearchItemResponse.from(exactIndoorPin))
+                    : List.of();
+            return MapSearchResponse.success(MapSearchResultType.FLOOR_MAP, data);
+        }
+
+        Category exactCategory = findExactCategory(keyword);
+        if (exactCategory != null) {
+            List<PinSummaryResponse> data = mapPinService.getPinsByCategory(
+                    exactCategory.getCode(), userLat, userLng, page, size, email, recommendationSeed);
+            return MapSearchResponse.success(MapSearchResultType.LABEL, data);
+        }
+
+        return MapSearchResponse.success(MapSearchResultType.GENERAL,
+                searchGeneral(keyword, userLat, userLng, page, size, email));
+    }
+
+    private List<PinSummaryResponse> searchGeneral(String keyword, Double userLat, Double userLng, int page, int size,
+                                                   String email) {
 
         // 검색 대상 핀을 연관과 함께 한 번에 로딩 (카테고리/소속건물/층)
         List<Pin> candidates = pinRepository.findAllForSearch();
@@ -82,13 +112,11 @@ public class MapSearchService {
         boolean hasGps = userLat != null && userLng != null;
         boolean insideCampus = distanceCalculator.isWithinCampus(userLat, userLng);
 
-        // 1. 종류 필터 + 관련도 점수 계산 (0 이하는 매칭 실패로 제외)
+        // 1. 관련도 점수 계산 (0 이하는 매칭 실패로 제외)
         List<Scored> scored = new ArrayList<>();
         for (Pin pin : candidates) {
-            if (typeFilter != null && pin.getType() != typeFilter) {
-                continue;
-            }
-            double relevance = matcher.score(pin.getName(), pin.getCategory().getLabel(), keyword);
+            double relevance = matcher.score(
+                    pin.getName(), null, pin.getIndoorCode(), keyword);
             if (relevance <= 0.0) {
                 continue;
             }
@@ -112,18 +140,17 @@ public class MapSearchService {
      * 거리·운영상태는 계산하지 않는다.
      *
      * @param keyword    검색어 (비면 빈 목록)
-     * @param typeFilter 종류 필터 (null이면 전체)
      * @param limit      최대 개수 (0 이하면 10)
      */
-    public List<MapSuggestResponse> suggest(String keyword, PinType typeFilter, int limit) {
+    public List<MapSuggestResponse> suggest(String keyword, int limit) {
         if (keyword == null || keyword.isBlank()) {
             return List.of();
         }
         int safeLimit = limit > 0 ? limit : 10;
 
         return pinRepository.findAllForSearch().stream()
-                .filter(pin -> typeFilter == null || pin.getType() == typeFilter)
-                .map(pin -> new Scored(pin, matcher.score(pin.getName(), pin.getCategory().getLabel(), keyword), null))
+                .map(pin -> new Scored(pin, matcher.score(
+                        pin.getName(), pin.getCategory().getLabel(), pin.getIndoorCode(), keyword), null))
                 .filter(s -> s.relevance() > 0.0)
                 .sorted(Comparator.comparingDouble(Scored::relevance).reversed()
                         .thenComparing(s -> s.pin().getName()))
@@ -154,7 +181,35 @@ public class MapSearchService {
                 operatingStatusLabel(pin, now),
                 displayDistance(pin, userLat, userLng, insideCampus),
                 pin.resolveLatitude(),
-                pin.resolveLongitude());
+                pin.resolveLongitude(),
+                pin.getIndoorCode());
+    }
+
+    /** 실내 코드는 공백·기호·대소문자를 무시하되 정확히 일치할 때만 층 안내도로 보낸다. */
+    private Pin findExactIndoorPin(String keyword) {
+        String indoorCode = matcher.normalize(keyword).toUpperCase();
+        if (indoorCode.isEmpty()) {
+            return null;
+        }
+        return pinRepository.findByIndoorCodeIgnoreCase(indoorCode)
+                .filter(pin -> pin.isInsideBuilding() && pin.getFloor() != null)
+                .orElse(null);
+    }
+
+    /** 등록된 명지도 라벨과 정확히 일치하면 일반 이름 검색보다 라벨 목록을 우선한다. */
+    private Category findExactCategory(String keyword) {
+        String normalizedKeyword = matcher.normalize(keyword);
+        if (normalizedKeyword.isEmpty()) {
+            return null;
+        }
+        return categoryRepository.findAll().stream()
+                .filter(category -> matcher.normalize(category.getLabel()).equals(normalizedKeyword))
+                .sorted(Comparator
+                        .comparing(Category::isTopLevel).reversed()
+                        .thenComparingInt(Category::getDisplayOrder)
+                        .thenComparing(Category::getId))
+                .findFirst()
+                .orElse(null);
     }
 
     /**

--- a/src/main/java/nova/mjs/domain/thingo/map/service/MapSyncServiceImpl.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/service/MapSyncServiceImpl.java
@@ -154,7 +154,7 @@ public class MapSyncServiceImpl implements MapSyncService {
                     .map(existing -> {
                         existing.update(category, row.getName(), row.getLatitude(), row.getLongitude(),
                                 row.getImageUrl(), row.getInfoText(), row.getBuildingNumber(), row.getClassroomCode(),
-                                null, null, null);
+                                null, null, null, null);
                         return existing;
                     })
                     .orElseGet(() -> pinRepository.save(Pin.ofBuilding(row.getCode(), category, row.getName(),
@@ -202,18 +202,20 @@ public class MapSyncServiceImpl implements MapSyncService {
                     ? null : resolveBuilding(row.getParentBuildingCode(), i, context);
             Floor floor = (parentBuilding != null && !isBlank(row.getFloorLabel()))
                     ? resolveFloor(row.getParentBuildingCode(), row.getFloorLabel(), i, context) : null;
+            String indoorCode = normalizeIndoorCode(row.getIndoorCode());
+            validateIndoorTarget(indoorCode, parentBuilding, floor, i);
 
             Pin place = pinRepository.findByCode(row.getCode())
                     .map(existing -> {
                         existing.update(category, row.getName(), row.getLatitude(), row.getLongitude(),
                                 row.getImageUrl(), row.getInfoText(), null, null,
-                                row.getAddress(), parentBuilding, floor);
+                                row.getAddress(), parentBuilding, floor, indoorCode);
                         return existing;
                     })
                     .orElseGet(() -> {
                         Pin created = parentBuilding != null
                                 ? Pin.ofInternalPlace(row.getCode(), category, row.getName(),
-                                    row.getImageUrl(), row.getInfoText(), parentBuilding, floor)
+                                    row.getImageUrl(), row.getInfoText(), parentBuilding, floor, indoorCode)
                                 : Pin.ofExternalPlace(row.getCode(), category, row.getName(),
                                     row.getLatitude(), row.getLongitude(), row.getImageUrl(),
                                     row.getInfoText(), row.getAddress());
@@ -301,6 +303,20 @@ public class MapSyncServiceImpl implements MapSyncService {
 
     private String floorKey(String buildingCode, String label) {
         return buildingCode + "::" + label;
+    }
+
+    private String normalizeIndoorCode(String value) {
+        if (isBlank(value)) {
+            return null;
+        }
+        return value.replaceAll("[^A-Za-z0-9]", "").toUpperCase();
+    }
+
+    private void validateIndoorTarget(String indoorCode, Pin parentBuilding, Floor floor, int index) {
+        if (indoorCode != null && (parentBuilding == null || floor == null)) {
+            throw invalidRow("places", index,
+                    "indoor_code를 입력하려면 parent_building_code와 floor_label이 필요합니다.");
+        }
     }
 
     // ====================== 검증/파싱 ======================

--- a/src/main/java/nova/mjs/domain/thingo/map/support/MapSearchMatcher.java
+++ b/src/main/java/nova/mjs/domain/thingo/map/support/MapSearchMatcher.java
@@ -50,6 +50,11 @@ public class MapSearchMatcher {
      * @param query         사용자 입력 검색어
      */
     public double score(String name, String categoryLabel, String query) {
+        return score(name, categoryLabel, null, query);
+    }
+
+    /** 이름·카테고리와 실제 실내 코드까지 비교한다. 정확한 호실 코드가 최우선이다. */
+    public double score(String name, String categoryLabel, String indoorCode, String query) {
         if (query == null || query.isBlank()) {
             return 0.0;
         }
@@ -71,6 +76,18 @@ public class MapSearchMatcher {
         String normalizedQuery = normalize(query);
         if (normalizedQuery.isEmpty()) {
             return 0.0;
+        }
+        String normalizedIndoorCode = normalize(indoorCode);
+        if (!normalizedIndoorCode.isEmpty()) {
+            if (normalizedIndoorCode.equals(normalizedQuery)) {
+                return 120.0;
+            }
+            if (normalizedIndoorCode.startsWith(normalizedQuery)) {
+                return 80.0;
+            }
+            if (normalizedIndoorCode.contains(normalizedQuery)) {
+                return 50.0;
+            }
         }
         String normalizedName = normalize(name);
 

--- a/src/main/java/nova/mjs/domain/thingo/search/service/PgUnifiedSearchService.java
+++ b/src/main/java/nova/mjs/domain/thingo/search/service/PgUnifiedSearchService.java
@@ -2,14 +2,18 @@ package nova.mjs.domain.thingo.search.service;
 
 import lombok.RequiredArgsConstructor;
 import nova.mjs.domain.thingo.search.dto.SearchResponseDTO;
+import nova.mjs.domain.thingo.map.entity.Pin;
+import nova.mjs.domain.thingo.map.repository.PinRepository;
 import nova.mjs.domain.thingo.search.model.SearchType;
 import nova.mjs.domain.thingo.realtimeKeyword.RealtimeKeywordService;
 import nova.mjs.domain.thingo.search.dto.SearchResultRow;
 import nova.mjs.domain.thingo.search.repository.UnifiedSearchIndexRepository;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
 import java.util.regex.Pattern;
@@ -32,6 +36,7 @@ public class PgUnifiedSearchService {
     private static final Pattern HOT_KEYWORD_SAFE = Pattern.compile("^[\\p{IsHangul}A-Za-z0-9]{2,20}$");
 
     private final UnifiedSearchIndexRepository repository;
+    private final PinRepository pinRepository;
     private final RealtimeKeywordService realtimeKeywordService;
 
     public Page<SearchResponseDTO> search(String keyword,
@@ -43,6 +48,18 @@ public class PgUnifiedSearchService {
         String normalizedType = normalizeType(type);
         String normalizedCategory = normalizeCategory(category);
         String normalizedKeyword = keyword == null ? "" : keyword.trim();
+
+        // S1353처럼 실제 호실 코드를 정확히 입력하면 게시물 인덱스를 거치지 않고
+        // 해당 층 안내도 결과를 최우선으로 반환한다.
+        if (normalizedType == null) {
+            Pin exactIndoorPin = findExactIndoorPin(normalizedKeyword, normalizedCategory);
+            if (exactIndoorPin != null) {
+                List<SearchResponseDTO> content = pageable.getPageNumber() == 0
+                        ? List.of(toMapResponse(exactIndoorPin))
+                        : List.of();
+                return new PageImpl<>(content, pageable, 1L);
+            }
+        }
         String hotPattern = buildHotPattern();
 
         Page<SearchResultRow> rows = repository.search(
@@ -97,6 +114,44 @@ public class PgUnifiedSearchService {
                 .topicIds(r.topicIds())
                 .directTopicIds(r.directTopicIds())
                 .build();
+    }
+
+    private Pin findExactIndoorPin(String keyword, String category) {
+        String indoorCode = normalizeIndoorCode(keyword);
+        if (indoorCode.isEmpty()) {
+            return null;
+        }
+        return pinRepository.findByIndoorCodeIgnoreCase(indoorCode)
+                .filter(pin -> category == null || category.equals(pin.getCategory().getCode()))
+                .orElse(null);
+    }
+
+    private SearchResponseDTO toMapResponse(Pin pin) {
+        String location = pin.getParentBuilding().getName() + " " + pin.getFloor().getLabel();
+        String link = UriComponentsBuilder.fromPath("/maps/floor")
+                .queryParam("buildingId", pin.getParentBuilding().getId())
+                .queryParam("floorLabel", pin.getFloor().getLabel())
+                .queryParam("target", pin.getIndoorCode())
+                .encode()
+                .toUriString();
+
+        return SearchResponseDTO.builder()
+                .id("MAP:" + pin.getId())
+                .highlightedTitle("<em>" + pin.getIndoorCode() + "</em>"
+                        + (pin.getIndoorCode().equalsIgnoreCase(pin.getName()) ? "" : " · " + pin.getName()))
+                .highlightedContent(location + " 층별 안내도")
+                .link(link)
+                .category(pin.getCategory().getCode())
+                .type("map")
+                .score(100.0f)
+                .build();
+    }
+
+    private String normalizeIndoorCode(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replaceAll("[^A-Za-z0-9]", "").toUpperCase();
     }
 
     private String academicSourceContent(SearchResultRow row) {

--- a/src/test/java/nova/mjs/domain/thingo/map/MapSearchE2EIT.java
+++ b/src/test/java/nova/mjs/domain/thingo/map/MapSearchE2EIT.java
@@ -5,17 +5,22 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import nova.mjs.domain.thingo.ElasticSearch.indexing.publisher.SearchIndexPublisher;
 import nova.mjs.domain.thingo.map.dto.MapSuggestResponse;
+import nova.mjs.domain.thingo.map.dto.FloorMapSearchItemResponse;
+import nova.mjs.domain.thingo.map.dto.MapSearchResponse;
+import nova.mjs.domain.thingo.map.dto.MapSearchResultType;
 import nova.mjs.domain.thingo.map.dto.MapSyncDTO;
 import nova.mjs.domain.thingo.map.dto.PinSummaryResponse;
 import nova.mjs.domain.thingo.map.entity.Pin;
 import nova.mjs.domain.thingo.map.entity.PinType;
 import nova.mjs.domain.thingo.map.repository.PinRepository;
 import nova.mjs.domain.thingo.map.service.MapSearchService;
+import nova.mjs.domain.thingo.map.service.MapPinService;
 import nova.mjs.domain.thingo.map.service.MapSyncService;
 import nova.mjs.domain.thingo.map.service.MapSyncServiceImpl;
 import nova.mjs.domain.thingo.map.support.CampusArea;
 import nova.mjs.domain.thingo.map.support.DistanceCalculator;
 import nova.mjs.domain.thingo.map.support.MapSearchMatcher;
+import nova.mjs.domain.thingo.map.support.MapRecommendationRanker;
 import nova.mjs.domain.thingo.map.support.OperatingStatusResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -72,7 +77,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import({
         MapSyncServiceImpl.class,
         MapSearchService.class,
+        MapPinService.class,
         MapSearchMatcher.class,
+        MapRecommendationRanker.class,
         DistanceCalculator.class,
         OperatingStatusResolver.class,
         CampusArea.class,
@@ -117,18 +124,21 @@ class MapSearchE2EIT {
                 {"code":"cafe","groupCode":"food","label":"카페","iconKey":"CafeIcon","resultType":"PLACE_LIST","quickMenu":true,"displayOrder":2},
                 {"code":"bar","groupCode":"food","label":"주점","iconKey":"BarIcon","resultType":"PLACE_LIST","quickMenu":false,"displayOrder":3},
                 {"code":"building","groupCode":"guide","label":"건물","iconKey":"BuildingIcon","resultType":"BUILDING_LIST","quickMenu":true,"displayOrder":1},
+                {"code":"classroom","groupCode":"guide","label":"강의실","iconKey":"ClassroomIcon","resultType":"PLACE_LIST","quickMenu":false,"displayOrder":2},
                 {"code":"printer","groupCode":"convenience","label":"프린터","iconKey":"PrinterIcon","resultType":"PLACE_LIST","quickMenu":false,"displayOrder":1}
               ],
               "buildings": [
                 {"code":"b-main","categoryCode":"building","name":"종합관","latitude":37.5803,"longitude":126.9223,"imageUrl":"https://thingo.kr/b1.jpg","infoText":"구 본관","buildingNumber":1,"classroomCode":"S1XXX"}
               ],
               "floors": [
-                {"buildingCode":"b-main","label":"F1","floorOrder":1,"mapImageUrl":"https://thingo.kr/f1.jpg"}
+                {"buildingCode":"b-main","label":"F1","floorOrder":1,"mapImageUrl":"https://thingo.kr/f1.jpg"},
+                {"buildingCode":"b-main","label":"F3","floorOrder":3,"mapImageUrl":"https://thingo.kr/f3.jpg"}
               ],
               "places": [
                 {"code":"p-happy","categoryCode":"korean","name":"행복식당","latitude":37.5805,"longitude":126.9230,"address":"서울 서대문구 거북골로 34","infoText":"현금만"},
                 {"code":"p-twosome","categoryCode":"cafe","name":"투썸플레이스 명지대점","latitude":37.5806,"longitude":126.9231,"address":"서울 서대문구 거북골로 31-1 1~3층","infoText":"콘센트 많음"},
                 {"code":"p-printer","categoryCode":"printer","name":"무한프린터","parentBuildingCode":"b-main","floorLabel":"F1","infoText":"흑백 50원"},
+                {"code":"p-s1353","categoryCode":"classroom","name":"강의실 S1353","parentBuildingCode":"b-main","floorLabel":"F3","indoorCode":"S1353"},
                 {"code":"p-twodari","categoryCode":"bar","name":"투다리 하나로점","latitude":37.5812,"longitude":126.9250,"address":"서울 서대문구 명지대길 18","infoText":"단체석 있음"}
               ],
               "operatingHours": [
@@ -156,14 +166,14 @@ class MapSearchE2EIT {
 
         // then - 섹션별 처리 건수
         assertThat(result.getGroups()).isEqualTo(3);
-        assertThat(result.getCategories()).isEqualTo(6);
+        assertThat(result.getCategories()).isEqualTo(7);
         assertThat(result.getBuildings()).isEqualTo(1);
-        assertThat(result.getFloors()).isEqualTo(1);
-        assertThat(result.getPlaces()).isEqualTo(4);
+        assertThat(result.getFloors()).isEqualTo(2);
+        assertThat(result.getPlaces()).isEqualTo(5);
         assertThat(result.getOperatingHours()).isEqualTo(2);
 
-        // 핀 총 5개 (건물1 + 장소4)
-        assertThat(pinRepository.count()).isEqualTo(5);
+        // 핀 총 6개 (건물1 + 장소5)
+        assertThat(pinRepository.count()).isEqualTo(6);
 
         // 개별 핀의 내용이 시트 값 그대로 적재됐는지 (데이터 품질)
         Pin twosome = pinRepository.findByCode("p-twosome").orElseThrow();
@@ -184,9 +194,11 @@ class MapSearchE2EIT {
         syncAndClear();
 
         // when
-        List<PinSummaryResponse> results = mapSearchService.search("종합", null, null, null, 0, 20, null);
+        MapSearchResponse response = search("종합");
+        List<PinSummaryResponse> results = pinResults(response);
 
         // then
+        assertThat(response.getResultType()).isEqualTo(MapSearchResultType.GENERAL);
         assertThat(results).extracting(PinSummaryResponse::getName).contains("종합관");
         assertThat(results).allSatisfy(r -> assertThat(r.getType()).isEqualTo("BUILDING"));
     }
@@ -198,7 +210,7 @@ class MapSearchE2EIT {
         syncAndClear();
 
         // when
-        List<PinSummaryResponse> results = mapSearchService.search("ㅌㅆ", null, null, null, 0, 20, null);
+        List<PinSummaryResponse> results = pinResults(search("ㅌㅆ"));
 
         // then
         assertThat(results).extracting(PinSummaryResponse::getName).contains("투썸플레이스 명지대점");
@@ -211,7 +223,7 @@ class MapSearchE2EIT {
         syncAndClear();
 
         // when
-        List<PinSummaryResponse> results = mapSearchService.search("투썹플레이스", null, null, null, 0, 20, null);
+        List<PinSummaryResponse> results = pinResults(search("투썹플레이스"));
 
         // then
         assertThat(results).extracting(PinSummaryResponse::getName).contains("투썸플레이스 명지대점");
@@ -224,7 +236,7 @@ class MapSearchE2EIT {
         syncAndClear();
 
         // when
-        List<PinSummaryResponse> results = mapSearchService.search("투썸", null, null, null, 0, 20, null);
+        List<PinSummaryResponse> results = pinResults(search("투썸"));
 
         // then - 카페(투썸플레이스)만 나오고, 이름이 다른 '투다리 하나로점'은 섞이지 않는다
         assertThat(results).extracting(PinSummaryResponse::getName)
@@ -239,27 +251,12 @@ class MapSearchE2EIT {
         syncAndClear();
 
         // when
-        List<PinSummaryResponse> results = mapSearchService.search("한식", null, null, null, 0, 20, null);
+        MapSearchResponse response = search("한식");
+        List<PinSummaryResponse> results = pinResults(response);
 
         // then
+        assertThat(response.getResultType()).isEqualTo(MapSearchResultType.LABEL);
         assertThat(results).extracting(PinSummaryResponse::getName).contains("행복식당");
-    }
-
-    @Test
-    @DisplayName("종류 필터: type=BUILDING/PLACE로 결과를 걸러낸다")
-    void should_filterByType() throws Exception {
-        // given
-        syncAndClear();
-
-        // when
-        List<PinSummaryResponse> twosomeAsBuilding = mapSearchService.search("투썸", PinType.BUILDING, null, null, 0, 20, null);
-        List<PinSummaryResponse> twosomeAsPlace = mapSearchService.search("투썸", PinType.PLACE, null, null, 0, 20, null);
-        List<PinSummaryResponse> jonghapAsBuilding = mapSearchService.search("종합", PinType.BUILDING, null, null, 0, 20, null);
-
-        // then - 투썸은 장소라 BUILDING 필터에선 안 나오고 PLACE 필터에선 나온다
-        assertThat(twosomeAsBuilding).isEmpty();
-        assertThat(twosomeAsPlace).extracting(PinSummaryResponse::getName).contains("투썸플레이스 명지대점");
-        assertThat(jonghapAsBuilding).extracting(PinSummaryResponse::getName).containsExactly("종합관");
     }
 
     @Test
@@ -269,9 +266,9 @@ class MapSearchE2EIT {
         syncAndClear();
 
         // when
-        PinSummaryResponse internalPrinter = only(mapSearchService.search("무한프린터", null, null, null, 0, 20, null));
-        PinSummaryResponse externalCafe = only(mapSearchService.search("투썸플레이스 명지대점", null, null, null, 0, 20, null));
-        PinSummaryResponse mainBuilding = only(mapSearchService.search("종합관", null, null, null, 0, 20, null));
+        PinSummaryResponse internalPrinter = only(search("무한프린터"));
+        PinSummaryResponse externalCafe = only(search("투썸플레이스 명지대점"));
+        PinSummaryResponse mainBuilding = only(search("종합관"));
 
         // then
         assertThat(internalPrinter.getOperatingStatus()).isNotNull();   // 소속 건물(종합관) 운영시간 상속
@@ -286,10 +283,39 @@ class MapSearchE2EIT {
         syncAndClear();
 
         // when
-        PinSummaryResponse printer = only(mapSearchService.search("무한프린터", null, null, null, 0, 20, null));
+        PinSummaryResponse printer = only(search("무한프린터"));
 
         // then
         assertThat(printer.getLocation()).isEqualTo("종합관 F1");
+    }
+
+    @Test
+    @DisplayName("정확한 호실 코드로 검색하면 층 안내도 링크 한 건을 반환한다")
+    void should_returnFloorMapLink_when_exactIndoorCodeMatches() throws Exception {
+        syncAndClear();
+
+        MapSearchResponse response = search("s-1353");
+        assertThat(response.getResultType()).isEqualTo(MapSearchResultType.FLOOR_MAP);
+        assertThat(response.getData()).hasSize(1);
+
+        FloorMapSearchItemResponse room = (FloorMapSearchItemResponse) response.getData().get(0);
+        assertThat(room.getId()).isNotNull();
+        assertThat(room.getName()).isEqualTo("강의실 S1353");
+        assertThat(room.getLink())
+                .contains("/maps/floor?buildingId=", "floorLabel=F3", "target=S1353")
+                .doesNotContain("pinId=", "xPercent", "yPercent");
+    }
+
+    @Test
+    @DisplayName("라벨명이 장소명과 겹쳐도 라벨 목록을 우선한다")
+    void should_prioritizeLabel_when_labelMatchesExactly() throws Exception {
+        syncAndClear();
+
+        MapSearchResponse response = search("카페");
+
+        assertThat(response.getResultType()).isEqualTo(MapSearchResultType.LABEL);
+        assertThat(pinResults(response)).extracting(PinSummaryResponse::getName)
+                .containsExactly("투썸플레이스 명지대점");
     }
 
     @Test
@@ -299,7 +325,7 @@ class MapSearchE2EIT {
         syncAndClear();
 
         // when
-        List<MapSuggestResponse> suggestions = mapSearchService.suggest("투", null, 10);
+        List<MapSuggestResponse> suggestions = mapSearchService.suggest("투", 10);
 
         // then
         assertThat(suggestions).extracting(MapSuggestResponse::getName).contains("투썸플레이스 명지대점");
@@ -313,12 +339,25 @@ class MapSearchE2EIT {
         syncAndClear();
 
         // when - then
-        assertThat(mapSearchService.search("  ", null, null, null, 0, 20, null)).isEmpty();
-        assertThat(mapSearchService.suggest("", null, 10)).isEmpty();
+        MapSearchResponse response = search("  ");
+        assertThat(response.getResultType()).isEqualTo(MapSearchResultType.GENERAL);
+        assertThat(response.getData()).isEmpty();
+        assertThat(mapSearchService.suggest("", 10)).isEmpty();
+    }
+
+    private MapSearchResponse search(String keyword) {
+        return mapSearchService.search(keyword, null, null, 0, 20, null, null);
+    }
+
+    private List<PinSummaryResponse> pinResults(MapSearchResponse response) {
+        return response.getData().stream()
+                .map(PinSummaryResponse.class::cast)
+                .toList();
     }
 
     /** 검색 결과에서 특정 핀 1건을 뽑는다 (이름이 유니크한 검색어 전제) */
-    private PinSummaryResponse only(List<PinSummaryResponse> results) {
+    private PinSummaryResponse only(MapSearchResponse response) {
+        List<PinSummaryResponse> results = pinResults(response);
         assertThat(results).isNotEmpty();
         return results.get(0);
     }

--- a/src/test/java/nova/mjs/domain/thingo/search/service/PgUnifiedSearchServiceTest.java
+++ b/src/test/java/nova/mjs/domain/thingo/search/service/PgUnifiedSearchServiceTest.java
@@ -1,6 +1,10 @@
 package nova.mjs.domain.thingo.search.service;
 
 import nova.mjs.domain.thingo.realtimeKeyword.RealtimeKeywordService;
+import nova.mjs.domain.thingo.map.entity.Category;
+import nova.mjs.domain.thingo.map.entity.Floor;
+import nova.mjs.domain.thingo.map.entity.Pin;
+import nova.mjs.domain.thingo.map.repository.PinRepository;
 import nova.mjs.domain.thingo.search.dto.SearchResponseDTO;
 import nova.mjs.domain.thingo.search.dto.SearchResultRow;
 import nova.mjs.domain.thingo.search.repository.UnifiedSearchIndexRepository;
@@ -14,6 +18,7 @@ import org.springframework.data.domain.PageRequest;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -21,16 +26,18 @@ import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class PgUnifiedSearchServiceTest {
 
     @Mock private UnifiedSearchIndexRepository repository;
+    @Mock private PinRepository pinRepository;
     @Mock private RealtimeKeywordService realtimeKeywordService;
 
     @Test
     void exposesFullSourceContentOnlyForAcademicGuides() {
-        PgUnifiedSearchService service = new PgUnifiedSearchService(repository, realtimeKeywordService);
+        PgUnifiedSearchService service = new PgUnifiedSearchService(repository, pinRepository, realtimeKeywordService);
         var pageable = PageRequest.of(0, 10);
         var academic = row("ACADEMIC_GUIDE:rule", "ACADEMIC_GUIDE", "학번별 전체 규칙");
         var notice = row("NOTICE:1", "NOTICE", "일반 공지 원문");
@@ -43,6 +50,35 @@ class PgUnifiedSearchServiceTest {
 
         assertThat(result.getContent().get(0).getContent()).isEqualTo("학번별 전체 규칙");
         assertThat(result.getContent().get(1).getContent()).isNull();
+    }
+
+    @Test
+    void exactIndoorCodeReturnsFloorMapBeforeDocumentSearch() {
+        PgUnifiedSearchService service = new PgUnifiedSearchService(repository, pinRepository, realtimeKeywordService);
+        var pageable = PageRequest.of(0, 10);
+        Pin room = org.mockito.Mockito.mock(Pin.class);
+        Pin building = org.mockito.Mockito.mock(Pin.class);
+        Floor floor = org.mockito.Mockito.mock(Floor.class);
+        Category category = org.mockito.Mockito.mock(Category.class);
+
+        when(pinRepository.findByIndoorCodeIgnoreCase("S1353")).thenReturn(Optional.of(room));
+        when(room.getId()).thenReturn(353L);
+        when(room.getIndoorCode()).thenReturn("S1353");
+        when(room.getName()).thenReturn("강의실 S1353");
+        when(room.getParentBuilding()).thenReturn(building);
+        when(room.getFloor()).thenReturn(floor);
+        when(room.getCategory()).thenReturn(category);
+        when(building.getId()).thenReturn(2L);
+        when(building.getName()).thenReturn("학생회관");
+        when(floor.getLabel()).thenReturn("F4");
+        when(category.getCode()).thenReturn("classroom");
+
+        Page<SearchResponseDTO> result = service.search("s-1353", null, null, "relevance", pageable);
+
+        SearchResponseDTO item = result.getContent().get(0);
+        assertThat(item.getType()).isEqualTo("map");
+        assertThat(item.getLink()).isEqualTo("/maps/floor?buildingId=2&floorLabel=F4&target=S1353");
+        verifyNoInteractions(repository);
     }
 
     private SearchResultRow row(String id, String type, String content) {


### PR DESCRIPTION
## 변경 내용
- 명지도 검색 요청의 `type` 필터를 제거했습니다.
- 정확한 실내 코드(예: `S1353`) 검색은 `FLOOR_MAP`으로 응답합니다.
- 정확한 카테고리/라벨 검색은 `LABEL`로 응답합니다.
- 그 외 검색은 `GENERAL`로 응답합니다.
- 층별 안내도 이동에 필요한 `buildingId`, `floorLabel`, 핀 좌표 및 실내 코드를 응답에 포함합니다.
- 자동완성 요청에서도 `type` 필터를 제거하고, 각 항목의 결과 `type`으로 이동 대상을 판단하도록 했습니다.
- 지도 동기화·저장 모델에 실내 코드를 연결하고 일반 검색에서도 정확한 강의실 검색 시 층별 안내도 정보를 반환하도록 했습니다.

## 확인
- `testClasses`
- `PgUnifiedSearchServiceTest`
- `MapSearchE2EIT`
- 모두 통과