### PR TITLE
docs(openapi): 즐겨찾기 그룹 color 팔레트 정의 명세 보강

### DIFF
--- a/src/main/resources/static/openapi/map.json
+++ b/src/main/resources/static/openapi/map.json
@@ -1001,7 +1001,7 @@
         ],
         "summary": "새 그룹 생성",
         "operationId": "createFavoriteGroup",
-        "description": "새 그룹 만들기(05-5-3) 바텀시트에서 그룹을 생성합니다.\n\n### 입력 규칙\n- `name`: **1~12자(공백 포함)**, 필수. 미입력/초과 시 `FAVORITE_GROUP_NAME_INVALID`.\n- `color`: 팔레트 10색 중 하나. 미지정 시 **기본 BLUE(띵고 색)**.\n\n생성 직후에는 담긴 장소가 없으므로 `placeCount=0`으로 내려갑니다.\n\n### 인증\n로그인 필요.",
+        "description": "새 그룹 만들기(05-5-3) 바텀시트에서 그룹을 생성합니다.\n\n### 입력 규칙\n- `name`: **1~12자(공백 포함)**, 필수. 미입력/초과 시 `FAVORITE_GROUP_NAME_INVALID`.\n- `color`: 팔레트 10색 **enum 이름** 중 하나(hex 코드가 아님). 미지정 시 **기본 BLUE(띵고 색)**.\n\n### 색상 팔레트(10색)\n게시판 글쓰기(노션형) 팔레트와 동일한 구성이며, 백엔드는 **enum 이름만 저장**합니다. 실제 표시용 hex 값은 프론트/공용 상수에서 이 이름과 1:1로 매핑합니다.\n\n순서대로: `CORAL`, `RED`, `ORANGE`, `AMBER`, `LIME`, `GREEN`, `SKY`, `BLUE`(기본·띵고 색), `PURPLE`, `GRAY`.\n\n생성 직후에는 담긴 장소가 없으므로 `placeCount=0`으로 내려갑니다.\n\n### 인증\n로그인 필요.",
         "security": [
           {
             "bearerAuth": []
@@ -3178,7 +3178,7 @@
               "PURPLE",
               "GRAY"
             ],
-            "description": "그룹 색상(팔레트 10색). 기본 BLUE",
+            "description": "그룹 색상. 팔레트 10색 enum 이름 중 하나(hex 아님). 순서: CORAL, RED, ORANGE, AMBER, LIME, GREEN, SKY, BLUE(기본), PURPLE, GRAY. 기본 BLUE(띵고 색). 실제 hex는 프론트/공용 상수에서 매핑.",
             "example": "CORAL"
           },
           "type": {
@@ -3231,7 +3231,7 @@
               "PURPLE",
               "GRAY"
             ],
-            "description": "그룹 색상. 미지정 시 BLUE",
+            "description": "그룹 색상. 팔레트 10색 enum 이름 중 하나(hex 아님). 순서: CORAL, RED, ORANGE, AMBER, LIME, GREEN, SKY, BLUE(기본), PURPLE, GRAY. 미지정 시 BLUE(띵고 색). 실제 hex는 프론트/공용 상수에서 매핑.",
             "example": "PURPLE"
           }
         }
@@ -3263,7 +3263,7 @@
               "PURPLE",
               "GRAY"
             ],
-            "description": "그룹 색상. 미지정 시 BLUE",
+            "description": "그룹 색상. 팔레트 10색 enum 이름 중 하나(hex 아님). 순서: CORAL, RED, ORANGE, AMBER, LIME, GREEN, SKY, BLUE(기본), PURPLE, GRAY. 미지정 시 BLUE(띵고 색). 실제 hex는 프론트/공용 상수에서 매핑.",
             "example": "RED"
           }
         }
@@ -3394,6 +3394,7 @@
               "PURPLE",
               "GRAY"
             ],
+            "description": "그룹 색상. 팔레트 10색 enum 이름 중 하나(hex 아님). 순서: CORAL, RED, ORANGE, AMBER, LIME, GREEN, SKY, BLUE(기본), PURPLE, GRAY. 기본 BLUE(띵고 색). 실제 hex는 프론트/공용 상수에서 매핑.",
             "example": "BLUE"
           },
           "type": {


### PR DESCRIPTION
## 개요
`POST /map/favorites/groups` 등 즐겨찾기 그룹 API의 `color` 필드가 **hex 코드가 아니라 팔레트 10색 enum 이름**임을 명세서에서 명확히 알 수 있도록 설명을 보강했습니다.

## 변경 내용
- `color`는 hex가 아닌 **enum 이름** 중 하나임을 명시
- 팔레트 10색 순서 명시: `CORAL, RED, ORANGE, AMBER, LIME, GREEN, SKY, BLUE(기본), PURPLE, GRAY`
- 기본값 `BLUE`(띵고 색) 안내
- 실제 표시용 **hex 값은 백엔드에 없고 프론트/공용 상수에서 이름과 1:1 매핑**됨을 안내
- 반영 위치: `POST /map/favorites/groups` 설명 + `FavoriteGroupCreateRequest` / `FavoriteGroupUpdateRequest` / Response 스키마의 `color` 필드 description

## 참고
- 색상 정의 원본: `src/main/java/nova/mjs/domain/thingo/map/entity/FavoriteGroupColor.java`
- 설계 문서: `docs/map-favorites-design.md`
- enum 값 자체는 이미 명세에 존재했으며, 이번 변경은 **설명(description) 보강**으로 동작·계약 변경은 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFx8YPjiGKxWeaszB4efJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFx8YPjiGKxWeaszB4efJo)_